### PR TITLE
feat: AGENTS.md export + llms.txt + Context7 + smart scaffolding (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,81 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-04-18
+
+Agentic-IDE reach + AI-friendly docs delivery. No code breaks anything
+under v1.0; §10.3 stdout bytes are preserved (no snapshot regen).
+
+### Features — agent surface
+
+- **`jellycell prompt --write [DIR]`** drops `AGENTS.md` + a 1-line
+  `CLAUDE.md` stub into the target directory (defaults to cwd).
+  `AGENTS.md` is the full `jellycell prompt` content with the MyST
+  `:::{important}` directive rewritten as a GitHub-rendered blockquote;
+  `CLAUDE.md` points at `AGENTS.md` so Claude Code picks it up via its
+  own convention. Single command, every AGENTS.md-native tool (Cursor,
+  Codex, GitHub Copilot, Aider, Zed, Warp, Windsurf, Junie, RooCode,
+  Gemini CLI, …) now sees jellycell's §10.3 guide. `--force` overwrites
+  existing files; `--agents-only` skips the `CLAUDE.md` stub.
+- **Monorepo-safe scatter prevention**: `jellycell prompt --write`
+  walks ancestors for an outer `AGENTS.md` (stops at `.git/`, `$HOME`,
+  or filesystem root) and refuses to write a duplicate inside unless
+  `--force` is passed. Agentic tools compose nested AGENTS.md files —
+  one file at the repo root covers every jellycell project underneath.
+- **`jellycell init` AGENTS.md hint**: end-of-init, `jellycell init`
+  detects whether an outer `AGENTS.md` already covers the target and
+  prints either `✓ agent guide detected at ../AGENTS.md` or a tip
+  showing how to add one via `jellycell prompt --write`. Advisory
+  only — `init` never writes `AGENTS.md` itself, no scaffold pollution.
+  `InitReport.agents_md_hint: str | None` exposes the detected path in
+  `--json` mode (§10.1 additive; no `schema_version` bump).
+- **`PromptWriteReport`** pydantic model for `jellycell prompt --write
+  --json` with `schema_version: 1`, `written`, `skipped`,
+  `outer_agents_md`. Pinned by `tests/integration/test_json_schemas.py`.
+
+### Docs — AI-friendly delivery
+
+- **`sphinx-llms-txt` integration**. The Sphinx build now emits
+  `docs/_build/html/llms.txt` (curated index of all project pages) and
+  `llms-full.txt` (full markdown concat). Read the Docs auto-serves
+  them at `https://jellycell.readthedocs.io/llms.txt` and
+  `/llms-full.txt` — single URLs that any agent (Cursor / Claude Code
+  / Codex with WebFetch) can ingest for up-to-date jellycell context.
+  Autodoc2-generated apidocs excluded from `llms.txt` to keep the index
+  curated; they flow through to `llms-full.txt`.
+- **`context7.json`** at repo root registers jellycell with the
+  [Context7](https://context7.com) MCP docs service. Users who run the
+  Context7 MCP (`@upstash/context7-mcp` or `https://mcp.context7.com/mcp`)
+  get jellycell's docs queryable alongside every other indexed library
+  without per-library MCP installs. **User-initiated step**: submit the
+  repo at [context7.com/add-library](https://context7.com/add-library)
+  to kick off indexing.
+
+### Docs — alignment
+
+- **`docs/getting-started.md`** — new "Bootstrap agent DX" step after
+  `jellycell init`; "Agent onboarding" section rewritten around
+  `--write`.
+- **`docs/index.md`** — "Agent-friendly" card updated with the new
+  one-command flow.
+- **`docs/project-layout.md`** — new "Multi-project / monorepo
+  pattern" section documenting the one-AGENTS.md-at-repo-root
+  convention + how jellycell's tooling enforces it.
+- **`docs/cli-reference.md`** — full `--write` / `--force` /
+  `--agents-only` documentation + monorepo-safety note.
+- **README.md** — quickstart gains the `jellycell prompt --write`
+  line; "Agents drop in without onboarding" bullet updated.
+
+### Contracts (§10)
+
+- §10.1 `--json` schemas: `InitReport` gains `agents_md_hint: str | None`
+  (additive, no bump). `PromptWriteReport` is new.
+- §10.2 cache key: unchanged. `MINOR_VERSION` stays at 1.
+- §10.3 agent guide content: **unchanged**. `jellycell prompt` stdout
+  bytes are byte-identical; the snapshot at
+  `tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml` is not
+  regenerated.
+
 ## [1.0.0] — 2026-04-18
 
 First public release.
@@ -165,5 +240,6 @@ Each contract has a documented ceremony for changes — see [docs/development/re
 - `cache prune` removes manifests but not blobs. diskcache deduplicates content-addressed storage so disk impact is small; a ref-counted blob GC lands in a future release.
 - `jc.cache` argument hashing uses pickle. Unpicklable inputs raise clearly at call time; a JSON-default fallback can come later.
 
-[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/random-walks/jellycell/releases/tag/v1.1.0
 [1.0.0]: https://github.com/random-walks/jellycell/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jellycell keeps the things that made notebooks useful (cell-level thinking, rich
 - **Outputs are content-addressed.** Every cell's output is keyed on `(normalized source, declared + detected deps, lockfile-aware env hash)`. Re-run → cache hit. Change a cell → only that cell + its dependents re-execute. Outputs live in a sidecar cache, not in your commits.
 - **Provenance is first-class.** Every artifact is tagged with the cell + notebook + cache key that produced it. `jc.load("artifacts/foo.json")` implicitly declares the dep edge. No hand-written DAGs.
 - **HTML reports are free.** `jellycell render` produces byte-identical static HTML; `jellycell view` serves the same pages live with SSE-backed reload while you edit. Side-nav, artifact browser, no build step.
-- **Agents drop in without onboarding.** Every CLI command supports `--json` with a versioned schema. `jellycell prompt` emits a canonical agent guide — the exact instructions Claude Code or your own agent needs to work in the project without hand-holding.
+- **Agents drop in without onboarding.** Every CLI command supports `--json` with a versioned schema. `jellycell prompt --write` drops `AGENTS.md` + `CLAUDE.md` at your repo root so Cursor, Codex, GitHub Copilot, Claude Code, Aider, and every other AGENTS.md-native tool picks up the canonical agent guide with zero config.
 
 ## Install
 
@@ -33,6 +33,9 @@ Requires Python ≥ 3.11.
 ```bash
 jellycell init my-project
 cd my-project
+
+# (Once per repo) drop AGENTS.md + CLAUDE.md so Cursor / Codex / Copilot / Claude Code read jellycell's agent guide
+jellycell prompt --write
 
 # Scaffold a notebook
 jellycell new tour

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,7 @@
+{
+  "projectTitle": "jellycell",
+  "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer. Agent-friendly via `jellycell prompt` (stdout) or `jellycell prompt --write` (AGENTS.md + CLAUDE.md).",
+  "folders": ["docs/"],
+  "excludeFolders": ["docs/_build", "docs/apidocs"],
+  "previousVersions": []
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -148,8 +148,36 @@ jellycell new analysis        # creates notebooks/analysis.py
 
 ### `jellycell prompt`
 
-Emit the canonical [agent guide](agent-guide.md) to stdout.
+Emit the canonical [agent guide](agent-guide.md) to stdout, or install
+it as `AGENTS.md` + `CLAUDE.md` with `--write`.
 
 ```bash
-jellycell prompt | pbcopy
+jellycell prompt | pbcopy                    # stdout — pipe into your agent
+jellycell prompt --write                     # drop AGENTS.md + CLAUDE.md in cwd
+jellycell prompt --write /path/to/repo-root  # target a specific directory
+jellycell prompt --write --agents-only       # skip the CLAUDE.md stub
+jellycell prompt --write --force             # overwrite existing files
 ```
+
+Flags:
+
+- `--write` — switch from stdout emission to disk-install mode. Without
+  it, the command behaves identically to pre-1.1 (§10.3 stability
+  contract preserves the stdout bytes).
+- `--force` — required to overwrite an existing `AGENTS.md` or
+  `CLAUDE.md`, or to write an inner override when an outer `AGENTS.md`
+  is detected in an ancestor directory.
+- `--agents-only` — write only `AGENTS.md`, skip the `CLAUDE.md` stub.
+  Useful when Claude Code isn't in the mix.
+
+**Monorepo safety**: `--write` walks up the directory tree looking for
+an existing `AGENTS.md` (stopping at the first `.git/` directory,
+`$HOME`, or filesystem root). If one is found in an ancestor, the
+command refuses to write an inner duplicate and prints a hint pointing
+at `--force`. See [project-layout.md](project-layout.md#multi-project--monorepo-pattern)
+for the recommended monorepo layout.
+
+**What's in AGENTS.md**: the same content as `jellycell prompt` stdout,
+with the MyST `:::{important}` directive rewritten as a plain-markdown
+blockquote so GitHub renders it natively. All other markdown is
+preserved verbatim.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinxcontrib.typer",
+    "sphinx_llms_txt",
 ]
 
 source_suffix = {
@@ -92,6 +93,21 @@ intersphinx_mapping = {
 
 copybutton_prompt_text = r"^\$ |^> "
 copybutton_prompt_is_regexp = True
+
+# -- sphinx-llms-txt ---------------------------------------------------------
+
+llms_txt_title = "jellycell"
+llms_txt_summary = (
+    "Reproducible-analysis notebook tool: plain-text .py notebooks in "
+    "jupytext percent format, content-addressed per-cell output cache, "
+    "live HTML viewer. The §10.3 agent guide is also available via "
+    "`jellycell prompt` (stdout) or `jellycell prompt --write` (AGENTS.md + "
+    "CLAUDE.md stub at your repo root)."
+)
+# The autodoc2 apidocs balloon the curated index; exclude from llms.txt but
+# let them flow through to llms-full.txt so agents pulling the full form
+# get the whole surface.
+llms_txt_exclude = ["apidocs/**"]
 
 # -- Nitpicky ----------------------------------------------------------------
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,33 @@ my-analysis/
 └── manuscripts/
 ```
 
+`jellycell init` also prints an AGENTS.md hint — either "✓ agent guide
+detected at ../AGENTS.md" if one already covers this subtree, or a tip
+showing how to add one. See the [next step](#bootstrap-agent-dx) to act
+on the tip.
+
+## Bootstrap agent DX
+
+If you want Cursor / Codex / GitHub Copilot / Claude Code / Aider to
+pick up jellycell's agent guide automatically, drop `AGENTS.md` +
+`CLAUDE.md` at your **repo root** (not the project root — one covers
+every jellycell project underneath):
+
+```bash
+cd my-repo     # the git root, which may contain multiple jellycell projects
+jellycell prompt --write
+```
+
+Writes `AGENTS.md` (full guide, rendered as plain markdown — `:::` MyST
+directives stripped) and `CLAUDE.md` (a 3-line stub pointing at
+`AGENTS.md`, since Claude Code reads `CLAUDE.md` by convention).
+
+If you later run `jellycell prompt --write` from inside a subdirectory
+that already has an outer `AGENTS.md`, jellycell refuses and explains —
+pass `--force` if you genuinely want an inner override. See
+[project-layout.md](project-layout.md#multi-project--monorepo-pattern)
+for the monorepo pattern.
+
 ## Write a notebook
 
 Create `notebooks/hello.py` (or run `jellycell new hello`):
@@ -106,12 +133,20 @@ jellycell export md notebooks/hello.py      # MyST markdown for Sphinx/Jupyter B
 
 ## Agent onboarding
 
+The canonical agent guide lives at `jellycell prompt` — the single
+source of truth for notebook format, tag vocabulary, `jc.*` API, and
+every CLI command. Two flows:
+
 ```bash
-jellycell prompt > /tmp/agent-context.md
+jellycell prompt                    # print to stdout (pipe into any agent's context)
+jellycell prompt --write            # drop AGENTS.md + CLAUDE.md at the repo root
 ```
 
-Pipe that into your agent's context and it knows the whole format, tag
-vocabulary, `jc.*` API, and CLI.
+The second is the one-command DX — AGENTS.md-native tools (Cursor,
+Codex, GitHub Copilot, Aider, Zed, Warp, Windsurf) pick it up
+automatically; Claude Code reads the `CLAUDE.md` stub that points to
+the same file. See [Bootstrap agent DX](#bootstrap-agent-dx) above for
+the monorepo-aware behavior.
 
 ## What next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Every cell's output is keyed on `(source, deps, env)`. Re-run is a cache hit; ch
 :::
 
 :::{grid-item-card} Agent-friendly
-Every command supports `--json`; `jellycell prompt` emits a canonical guide so Claude Code / OpenAI agents drop in without onboarding.
+Every command supports `--json`. `jellycell prompt --write` drops `AGENTS.md` + `CLAUDE.md` at your repo root so Cursor, Codex, Copilot, Claude Code, and Aider pick up the canonical agent guide automatically.
 :::
 ::::
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -18,6 +18,47 @@ my-project/
 
 All paths are configurable — see the `[paths]` section of `jellycell.toml`.
 
+## Multi-project / monorepo pattern
+
+One repo can hold several jellycell projects side by side — a
+marketing-analysis project next to a churn-model project, for instance.
+The right layout puts a single `AGENTS.md` at the **repo root**, not
+one per jellycell project:
+
+```
+my-repo/
+├── AGENTS.md                       # one agent guide covering everything
+├── CLAUDE.md                       # 3-line stub → AGENTS.md
+├── README.md
+├── pyproject.toml                  # or requirements.txt / uv.lock / ...
+├── marketing-analysis/             # a jellycell project
+│   ├── jellycell.toml
+│   ├── notebooks/
+│   ├── artifacts/
+│   └── site/
+└── churn-model/                    # another jellycell project
+    ├── jellycell.toml
+    ├── notebooks/
+    ├── artifacts/
+    └── site/
+```
+
+One AGENTS.md at repo root covers every jellycell project underneath.
+Agentic tools (Cursor, Codex, Copilot, Aider, Zed, Windsurf) compose
+nested AGENTS.md files — an outer file applies to every inner path
+unless an inner one overrides it. Jellycell's tooling is aware of this:
+
+- `jellycell init <subdir>` detects an outer `AGENTS.md` and prints
+  `✓ agent guide detected at ../AGENTS.md — Cursor / Codex / Copilot /
+  Claude Code already covered.` (instead of the usual "tip: add one").
+- `jellycell prompt --write <subdir>` refuses to scatter a duplicate
+  inside `<subdir>` when an outer `AGENTS.md` is found. Pass `--force`
+  only if you want an inner override for that subtree.
+
+The walk stops at the repo's `.git/` directory (or `$HOME`, or the
+filesystem root — whichever comes first), so AGENTS.md files sitting
+in random ancestor directories above the repo don't trip the check.
+
 ## Full `jellycell.toml` reference
 
 See [`jellycell.toml.example`](https://github.com/random-walks/jellycell/blob/main/jellycell.toml.example) in the repo root for a commented reference. Sections:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
     "sphinxcontrib-typer>=0.5",
     "sphinx-design>=0.6",
     "sphinx-copybutton>=0.5",
+    "sphinx-llms-txt>=0.7",
 ]
 examples = [
     "numpy>=1.26",

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.

--- a/src/jellycell/cli/commands/init.py
+++ b/src/jellycell/cli/commands/init.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from rich.console import Console
 
 from jellycell.cli.app import GlobalOptions, app
+from jellycell.cli.commands.prompt import _find_outer_agents_md
 from jellycell.config import default_config
 
 _console = Console()
@@ -22,6 +23,7 @@ class InitReport(BaseModel):
     path: str
     name: str
     created: list[str]
+    agents_md_hint: str | None = None
 
 
 @app.command("init", help="Scaffold a new jellycell project.")
@@ -53,7 +55,13 @@ def init(
             keep.write_text("", encoding="utf-8")
         created.append(f"{d}/")
 
-    report = InitReport(path=str(target), name=project_name, created=created)
+    outer = _find_outer_agents_md(target)
+    report = InitReport(
+        path=str(target),
+        name=project_name,
+        created=created,
+        agents_md_hint=str(outer) if outer else None,
+    )
 
     if opts.json_output:
         typer.echo(report.model_dump_json())
@@ -61,6 +69,16 @@ def init(
         _console.print(f"[green]ok[/green] initialized jellycell project at {target}")
         for name_item in report.created:
             _console.print(f"  [dim]+ {name_item}[/dim]")
+        if outer is not None:
+            _console.print(
+                f"  [dim]✓ agent guide detected at {outer} — "
+                "Cursor / Codex / Copilot / Claude Code already covered.[/dim]"
+            )
+        else:
+            _console.print(
+                "  [dim]tip: run 'jellycell prompt --write <repo-root>' to drop "
+                "AGENTS.md + CLAUDE.md so agentic tools read jellycell's guide.[/dim]"
+            )
 
 
 def _fail(opts: GlobalOptions, msg: str) -> None:

--- a/src/jellycell/cli/commands/prompt.py
+++ b/src/jellycell/cli/commands/prompt.py
@@ -1,27 +1,60 @@
-"""`jellycell prompt` — emit the canonical agent guide to stdout.
+"""`jellycell prompt` — emit the agent guide to stdout, or write it to disk.
 
-Spec §10.3 contract: the bytes emitted here are stable across patch
-versions. Sourced from :file:`docs/agent-guide.md` at install time.
+Spec §10.3 contract: the bytes emitted in stdout mode (``jellycell prompt``
+with no flags) are stable across patch versions. Sourced from
+:file:`docs/agent-guide.md` at install time.
+
+With ``--write`` the command drops ``AGENTS.md`` + a ``CLAUDE.md`` stub into
+the target directory so agentic tools (Cursor, Codex, Copilot, Aider, and
+Claude Code via the stub) pick up jellycell's guide at the repo level.
 """
 
 from __future__ import annotations
 
+import json
+import re
 from importlib import resources
+from pathlib import Path
+from typing import NoReturn
 
 import typer
+from pydantic import BaseModel
+from rich.console import Console
 
-from jellycell.cli.app import app
+from jellycell.cli.app import GlobalOptions, app
+
+_console = Console()
+
+_MYST_IMPORTANT_RE = re.compile(
+    r"^:::\{important\}\n(?P<body>.*?)\n:::\n",
+    re.DOTALL | re.MULTILINE,
+)
+_MYST_ANY_DIRECTIVE_RE = re.compile(r"^:::\{[^}]+\}", re.MULTILINE)
+
+_CLAUDE_STUB = """\
+# CLAUDE.md
+
+Follow [`AGENTS.md`](AGENTS.md). This stub exists because Claude Code
+reads `CLAUDE.md` by convention; the actual guide is in `AGENTS.md`
+(the AGENTS.md spec, which Cursor / Codex / Copilot / Aider / Zed also
+read natively).
+"""
+
+
+class PromptWriteReport(BaseModel):
+    """JSON schema for ``jellycell prompt --write --json``. Spec §10.1 contract."""
+
+    schema_version: int = 1
+    written: list[str]
+    skipped: list[str]
+    outer_agents_md: str | None = None
 
 
 def _read_guide() -> str:
     """Load the agent guide from package resources."""
-    # Installed packages: importlib.resources
     try:
         return (resources.files("jellycell") / "agent-guide.md").read_text(encoding="utf-8")
     except (FileNotFoundError, ModuleNotFoundError):
-        # Dev editable: fall back to docs/agent-guide.md in the repo.
-        from pathlib import Path
-
         repo_root = Path(__file__).resolve().parents[4]
         candidate = repo_root / "docs" / "agent-guide.md"
         if candidate.exists():
@@ -29,7 +62,140 @@ def _read_guide() -> str:
         return "# Agent guide\n\n(Agent guide not bundled with this install.)\n"
 
 
-@app.command("prompt", help="Emit the canonical agent guide to stdout.")
-def prompt() -> None:
-    """Print the agent guide (stable across patch releases)."""
-    typer.echo(_read_guide(), nl=False)
+def _to_agents_md(guide: str) -> str:
+    """Transform the Sphinx-flavored guide into plain-markdown AGENTS.md.
+
+    Replaces the ``:::{important}…:::`` MyST directive with a GitHub-compatible
+    blockquote. Raises ``ValueError`` on any other MyST directive so the narrow
+    transform here fails loud if the guide grows new Sphinx-only constructs.
+    """
+    match = _MYST_IMPORTANT_RE.search(guide)
+    if match:
+        body = match.group("body").strip()
+        quoted = "\n".join(f"> {line}" if line.strip() else ">" for line in body.splitlines())
+        replacement = f"> **Note:**\n>\n{quoted}\n"
+        guide = guide.replace(match.group(0), replacement)
+    remaining = _MYST_ANY_DIRECTIVE_RE.search(guide)
+    if remaining is not None:
+        raise ValueError(
+            f"unknown MyST directive in agent guide: {remaining.group(0)!r}. "
+            "Update _to_agents_md() to handle it explicitly."
+        )
+    return guide
+
+
+def _find_outer_agents_md(start: Path) -> Path | None:
+    """Walk ancestors of ``start`` looking for ``AGENTS.md``.
+
+    Stops when we hit a ``.git/`` directory (repo root), ``$HOME``, or the
+    filesystem root — whichever is closest. ``start`` itself is NOT checked
+    for AGENTS.md (that's the caller's concern) but IS checked for ``.git/``:
+    if ``start`` is the repo root, there's no outer AGENTS.md to find.
+    """
+    start = start.resolve()
+    home = Path.home().resolve()
+    if (start / ".git").exists():
+        return None
+    for ancestor in start.parents:
+        if (ancestor / "AGENTS.md").is_file():
+            return ancestor / "AGENTS.md"
+        if (ancestor / ".git").exists():
+            return None
+        if ancestor == home or ancestor == ancestor.parent:
+            return None
+    return None
+
+
+@app.command(
+    "prompt",
+    help="Emit the agent guide to stdout, or with --write drop AGENTS.md + CLAUDE.md.",
+)
+def prompt(
+    ctx: typer.Context,
+    directory: Path | None = typer.Argument(
+        None, help="Target directory (with --write). Defaults to cwd."
+    ),
+    write: bool = typer.Option(
+        False, "--write", help="Write AGENTS.md + CLAUDE.md to DIRECTORY instead of stdout."
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite existing AGENTS.md / CLAUDE.md."),
+    agents_only: bool = typer.Option(
+        False, "--agents-only", help="Skip the CLAUDE.md stub (AGENTS.md only)."
+    ),
+) -> None:
+    """Emit the canonical agent guide, or install it as AGENTS.md + CLAUDE.md."""
+    opts: GlobalOptions = ctx.obj
+    if not write:
+        if directory is not None:
+            _fail(opts, "DIRECTORY only applies with --write.")
+        typer.echo(_read_guide(), nl=False)
+        return
+    target = (directory or Path.cwd()).resolve()
+    _do_write(opts, target, force=force, agents_only=agents_only)
+
+
+def _do_write(opts: GlobalOptions, target: Path, *, force: bool, agents_only: bool) -> None:
+    if not target.is_dir():
+        _fail(opts, f"{target} is not a directory.")
+
+    agents_path = target / "AGENTS.md"
+    claude_path = target / "CLAUDE.md"
+
+    outer = _find_outer_agents_md(target)
+    if outer is not None and not force:
+        _fail(
+            opts,
+            f"found AGENTS.md at {outer} — agentic tools compose nested "
+            "AGENTS.md files, so the outer one already applies here. "
+            "Re-run with --force to write an inner override for this subdirectory.",
+        )
+
+    conflicts: list[Path] = []
+    if agents_path.exists():
+        conflicts.append(agents_path)
+    if not agents_only and claude_path.exists():
+        conflicts.append(claude_path)
+    if conflicts and not force:
+        names = ", ".join(str(c) for c in conflicts)
+        _fail(opts, f"{names} already exist. Use --force to overwrite.")
+
+    try:
+        agents_content = _to_agents_md(_read_guide())
+    except ValueError as exc:
+        _fail(opts, str(exc))
+
+    written: list[str] = []
+    skipped: list[str] = []
+    agents_path.write_text(agents_content, encoding="utf-8")
+    written.append(str(agents_path))
+    if agents_only:
+        skipped.append(str(claude_path))
+    else:
+        claude_path.write_text(_CLAUDE_STUB, encoding="utf-8")
+        written.append(str(claude_path))
+
+    report = PromptWriteReport(
+        written=written,
+        skipped=skipped,
+        outer_agents_md=str(outer) if outer else None,
+    )
+    if opts.json_output:
+        typer.echo(report.model_dump_json())
+    else:
+        for path in written:
+            _console.print(f"[green]wrote[/green] {path}")
+        for path in skipped:
+            _console.print(f"[dim]skipped[/dim] {path}")
+        if outer is not None:
+            _console.print(
+                f"[yellow]note:[/yellow] outer AGENTS.md at {outer} — "
+                "inner override wins for this subtree per the AGENTS.md spec."
+            )
+
+
+def _fail(opts: GlobalOptions, msg: str) -> NoReturn:
+    if opts.json_output:
+        typer.echo(json.dumps({"schema_version": 1, "error": msg}))
+    else:
+        _console.print(f"[red]error:[/red] {msg}")
+    raise typer.Exit(1)

--- a/tests/integration/test_init_agents_hint.py
+++ b/tests/integration/test_init_agents_hint.py
@@ -1,0 +1,68 @@
+"""Integration tests for the AGENTS.md hint printed by ``jellycell init``.
+
+The hint never auto-writes. It just surfaces a context-aware message:
+- Tip when no outer AGENTS.md is found.
+- Confirmation when one already covers the subtree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from jellycell.cli.app import app
+
+pytestmark = pytest.mark.integration
+
+runner = CliRunner()
+
+
+class TestHintOutput:
+    def test_prints_tip_when_no_outer_agents_md(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        target = tmp_path / "my-proj"
+        result = runner.invoke(app, ["init", str(target)])
+        assert result.exit_code == 0, result.output
+        assert "tip:" in result.output
+        assert "jellycell prompt --write" in result.output
+        assert "AGENTS.md" in result.output
+
+    def test_notes_detection_when_outer_agents_md_exists(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# monorepo", encoding="utf-8")
+        target = tmp_path / "my-proj"
+        result = runner.invoke(app, ["init", str(target)])
+        assert result.exit_code == 0, result.output
+        assert "agent guide detected at" in result.output
+        assert "tip:" not in result.output  # don't spam when already covered
+
+    def test_never_writes_agents_md(self, tmp_path: Path) -> None:
+        """The hint is advisory — init does not create AGENTS.md itself."""
+        (tmp_path / ".git").mkdir()
+        target = tmp_path / "my-proj"
+        runner.invoke(app, ["init", str(target)])
+        assert not (target / "AGENTS.md").exists()
+        assert not (target / "CLAUDE.md").exists()
+
+
+class TestJsonOutput:
+    def test_report_includes_agents_md_hint_when_none(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        target = tmp_path / "my-proj"
+        result = runner.invoke(app, ["--json", "init", str(target)])
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output.strip().splitlines()[-1])
+        assert report["schema_version"] == 1
+        assert "agents_md_hint" in report
+        assert report["agents_md_hint"] is None
+
+    def test_report_populates_agents_md_hint_when_outer_found(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        target = tmp_path / "my-proj"
+        result = runner.invoke(app, ["--json", "init", str(target)])
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output.strip().splitlines()[-1])
+        assert report["agents_md_hint"] is not None
+        assert report["agents_md_hint"].endswith("AGENTS.md")

--- a/tests/integration/test_json_schemas.py
+++ b/tests/integration/test_json_schemas.py
@@ -128,6 +128,15 @@ class TestSchemas:
             r.close()
         data_regression.check(_shape(report.model_dump()), basename="run_report")
 
+    def test_prompt_write(self, tmp_path: Path, data_regression: pytest.FixtureRequest) -> None:
+        # .git marker prevents the outer-AGENTS.md walk from wandering.
+        (tmp_path / ".git").mkdir()
+        _snapshot(
+            data_regression,
+            ["--json", "prompt", "--write", str(tmp_path)],
+            basename="prompt_write",
+        )
+
     def test_render(self, tmp_path: Path, data_regression: pytest.FixtureRequest) -> None:
         project = _project(tmp_path)
         nb = project.notebooks_dir / "nb.py"

--- a/tests/integration/test_json_schemas/init.yml
+++ b/tests/integration/test_json_schemas/init.yml
@@ -1,3 +1,4 @@
+agents_md_hint: 'null'
 created:
 - str
 name: str

--- a/tests/integration/test_json_schemas/prompt_write.yml
+++ b/tests/integration/test_json_schemas/prompt_write.yml
@@ -1,0 +1,6 @@
+outer_agents_md: 'null'
+schema_version: int
+skipped:
+- <empty>
+written:
+- str

--- a/tests/integration/test_prompt_write.py
+++ b/tests/integration/test_prompt_write.py
@@ -1,0 +1,155 @@
+"""Integration tests for ``jellycell prompt --write``.
+
+Covers the disk-write flow: file creation, `--force` overwrite semantics,
+`--agents-only` skipping the CLAUDE.md stub, custom target dir, and
+smart duplicate detection against an outer AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from jellycell.cli.app import app
+
+pytestmark = pytest.mark.integration
+
+runner = CliRunner()
+
+
+class TestBasicWrite:
+    def test_write_creates_agents_md_and_claude_md(self, tmp_path: Path) -> None:
+        # Simulate a fresh repo: .git present so `_find_outer_agents_md` stops there.
+        (tmp_path / ".git").mkdir()
+        result = runner.invoke(app, ["prompt", "--write", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        agents = tmp_path / "AGENTS.md"
+        claude = tmp_path / "CLAUDE.md"
+        assert agents.is_file()
+        assert claude.is_file()
+        content = agents.read_text(encoding="utf-8")
+        assert content.startswith("# Agent guide")
+        # MyST directive stripped.
+        assert ":::" not in content
+        assert "> **Note:**" in content
+        # Stub points at AGENTS.md.
+        assert "Follow [`AGENTS.md`]" in claude.read_text(encoding="utf-8")
+
+    def test_write_defaults_to_cwd(self, tmp_path: Path) -> None:
+        """``jellycell prompt --write`` with no DIR writes to cwd."""
+        (tmp_path / ".git").mkdir()
+        # Use typer's `invoke(... env)` / os.chdir via runner.
+        import os
+
+        cwd = Path.cwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["prompt", "--write"])
+        finally:
+            os.chdir(cwd)
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "AGENTS.md").is_file()
+        assert (tmp_path / "CLAUDE.md").is_file()
+
+    def test_agents_only_skips_claude_stub(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        result = runner.invoke(app, ["prompt", "--write", "--agents-only", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "AGENTS.md").is_file()
+        assert not (tmp_path / "CLAUDE.md").exists()
+
+
+class TestOverwriteSafety:
+    def test_refuses_to_overwrite_without_force(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "AGENTS.md").write_text("existing", encoding="utf-8")
+        result = runner.invoke(app, ["prompt", "--write", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "already exist" in result.output
+        # Original untouched.
+        assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "existing"
+
+    def test_force_overwrites(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "AGENTS.md").write_text("existing", encoding="utf-8")
+        (tmp_path / "CLAUDE.md").write_text("existing claude", encoding="utf-8")
+        result = runner.invoke(app, ["prompt", "--write", "--force", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8").startswith("# Agent guide")
+
+
+class TestOuterAgentsDetection:
+    def test_refuses_when_outer_agents_md_exists(self, tmp_path: Path) -> None:
+        """Monorepo safety: if a parent has AGENTS.md, don't scatter a copy inside."""
+        # No .git marker — the walk will find the outer AGENTS.md.
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub-project"
+        inner.mkdir()
+        result = runner.invoke(app, ["prompt", "--write", str(inner)])
+        assert result.exit_code == 1
+        assert "found AGENTS.md at" in result.output
+        assert "--force" in result.output
+        assert not (inner / "AGENTS.md").exists()
+
+    def test_force_overrides_outer_warning(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub-project"
+        inner.mkdir()
+        result = runner.invoke(app, ["prompt", "--write", "--force", str(inner)])
+        assert result.exit_code == 0, result.output
+        assert (inner / "AGENTS.md").is_file()
+        # Outer one is untouched.
+        assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "# outer"
+
+    def test_git_root_stops_outer_walk(self, tmp_path: Path) -> None:
+        """``.git/`` marks the repo root — outer AGENTS.md above it is ignored."""
+        # Outer AGENTS.md above the git root should NOT be detected.
+        outer_repo = tmp_path / "outer-workspace"
+        outer_repo.mkdir()
+        (outer_repo / "AGENTS.md").write_text("# ancestor", encoding="utf-8")
+        repo = outer_repo / "my-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        result = runner.invoke(app, ["prompt", "--write", str(repo)])
+        assert result.exit_code == 0, result.output
+        assert (repo / "AGENTS.md").is_file()
+
+
+class TestInputValidation:
+    def test_rejects_directory_without_write(self, tmp_path: Path) -> None:
+        """A positional DIRECTORY without --write is ambiguous; error out."""
+        result = runner.invoke(app, ["prompt", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "only applies with --write" in result.output
+
+    def test_rejects_non_directory_target(self, tmp_path: Path) -> None:
+        file_target = tmp_path / "not-a-dir"
+        file_target.write_text("", encoding="utf-8")
+        result = runner.invoke(app, ["prompt", "--write", str(file_target)])
+        assert result.exit_code == 1
+        assert "not a directory" in result.output
+
+
+class TestJsonOutput:
+    def test_json_report_shape(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        result = runner.invoke(app, ["--json", "prompt", "--write", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output.strip().splitlines()[-1])
+        assert report["schema_version"] == 1
+        assert len(report["written"]) == 2
+        assert report["skipped"] == []
+        assert report["outer_agents_md"] is None
+
+    def test_json_populates_outer_agents_md_on_force(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        result = runner.invoke(app, ["--json", "prompt", "--write", "--force", str(inner)])
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output.strip().splitlines()[-1])
+        assert report["outer_agents_md"] is not None
+        assert report["outer_agents_md"].endswith("AGENTS.md")

--- a/tests/unit/test_prompt_agents_md.py
+++ b/tests/unit/test_prompt_agents_md.py
@@ -1,0 +1,55 @@
+"""Unit tests for the ``_to_agents_md`` transform.
+
+Narrow by design — turns the Sphinx-flavored agent guide into plain
+markdown suitable for ``AGENTS.md``. Any unknown MyST directive must
+fail loud so the transform stays in sync with the guide as it evolves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jellycell.cli.commands.prompt import _to_agents_md
+
+
+class TestMySTImportantDirective:
+    def test_strips_myst_important_block(self) -> None:
+        src = (
+            "# Agent guide\n"
+            "\n"
+            ":::{important}\n"
+            "Spec §10.3 stability contract.\n"
+            "Patch-version releases MUST NOT change this page.\n"
+            ":::\n"
+            "\n"
+            "## What jellycell is\n"
+        )
+        out = _to_agents_md(src)
+        # The literal directive markers are gone.
+        assert ":::" not in out
+        assert "{important}" not in out
+
+    def test_replaces_with_github_blockquote(self) -> None:
+        src = "# T\n\n:::{important}\nRule one.\nRule two.\n:::\n"
+        out = _to_agents_md(src)
+        # GitHub renders `> **Note:**` as a native-looking callout.
+        assert "> **Note:**" in out
+        # The body lines land inside the blockquote.
+        assert "> Rule one." in out
+        assert "> Rule two." in out
+
+    def test_noop_when_directive_absent(self) -> None:
+        src = "# Agent guide\n\nJust plain markdown here.\n"
+        assert _to_agents_md(src) == src
+
+
+class TestFailsLoud:
+    def test_fails_on_unknown_directive(self) -> None:
+        src = "# T\n\n:::{important}\nok\n:::\n\n:::{warning}\nnot supported\n:::\n"
+        with pytest.raises(ValueError, match="unknown MyST directive"):
+            _to_agents_md(src)
+
+    def test_error_identifies_the_unknown_directive(self) -> None:
+        src = "# T\n\n:::{note}\nhi\n:::\n"
+        with pytest.raises(ValueError, match="note"):
+            _to_agents_md(src)

--- a/uv.lock
+++ b/uv.lock
@@ -1242,6 +1242,7 @@ dev = [
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinx-llms-txt" },
     { name = "sphinxcontrib-typer" },
     { name = "sse-starlette" },
     { name = "starlette" },
@@ -1258,6 +1259,7 @@ docs = [
     { name = "sphinx-autodoc2" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinx-llms-txt" },
     { name = "sphinxcontrib-typer" },
 ]
 examples = [
@@ -1320,6 +1322,8 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
     { name = "sphinx-design", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6" },
+    { name = "sphinx-llms-txt", marker = "extra == 'dev'", specifier = ">=0.7" },
+    { name = "sphinx-llms-txt", marker = "extra == 'docs'", specifier = ">=0.7" },
     { name = "sphinxcontrib-typer", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "sphinxcontrib-typer", marker = "extra == 'docs'", specifier = ">=0.5" },
     { name = "sse-starlette", marker = "extra == 'all'", specifier = ">=2" },
@@ -3197,6 +3201,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl", hash = "sha256:f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282", size = 2220350, upload-time = "2026-01-19T13:12:51.077Z" },
+]
+
+[[package]]
+name = "sphinx-llms-txt"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/dd/6d7fa7d6f51ee20959f1734cdbd62e99880dcd87576ce554d4bb8aaabdd7/sphinx_llms_txt-0.7.1.tar.gz", hash = "sha256:b5cefec19d3fd56670aa4a28917d17d32b22c61a9feadbab8564ad11e932f5c0", size = 32464, upload-time = "2025-12-16T22:31:26.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/17/a751012a0910e3c3afa41a5d40bdf00132466d072d25891ae7ec1f70dafd/sphinx_llms_txt-0.7.1-py3-none-any.whl", hash = "sha256:8f1cfcfe5897f5be118792f33f73eeb04cbbf66fc60c4c15982ec59252522263", size = 22545, upload-time = "2025-12-16T22:31:25.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three small moves gain jellycell reach across every agentic coding tool, with zero hosted infrastructure.

- **AGENTS.md export** — `jellycell prompt --write` drops `AGENTS.md` + a 1-line `CLAUDE.md` stub at the target directory. The \`§10.3\` guide becomes discoverable by Cursor, Codex, GitHub Copilot, Aider, Zed, Warp, Windsurf, Junie, Gemini CLI, RooCode — every AGENTS.md-native tool — with one command. Claude Code picks it up via the `CLAUDE.md` stub.
- **Monorepo-safe scattering prevention** — `--write` walks ancestors for an outer `AGENTS.md` (stops at `.git/` / `$HOME` / fs root). If one covers the target subtree, the command refuses to write a duplicate without `--force`. `jellycell init` surfaces the same detection as a one-line tip/confirmation, but never auto-writes.
- **docs-for-agents delivery** — `sphinx-llms-txt` now emits `llms.txt` (curated index) + `llms-full.txt` (full concat), which RTD auto-serves. `context7.json` at repo root registers jellycell with the Context7 MCP docs service for zero-hosting global reach.

Version 1.0.0 → **1.1.0** (additive CLI flag is a minor bump per [releasing.md](docs/development/releasing.md)). §10.3 stdout bytes byte-identical — snapshot not regenerated.

## Test plan

- [ ] \`make lint && make test && make docs-build && make release-check\` locally (done — 376 passed, clean)
- [ ] Smoke \`jellycell prompt --write\` in a fresh tempdir (done — basic write, overwrite safety, `--agents-only`, JSON, monorepo refuse/force all behave)
- [ ] Smoke \`jellycell init\` hint (done — tip printed when absent, confirmation when outer AGENTS.md found, JSON field populated)
- [ ] Verify \`llms.txt\` + \`llms-full.txt\` generated under \`docs/_build/html/\` (done — 23-line curated index, 2338-line full concat)
- [ ] Post-merge: user submits repo to [context7.com/add-library](https://context7.com/add-library), tags v1.1.0, pushes — release workflow publishes 1.1.0 to PyPI via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)