### PR TITLE
docs(context7): curated context7.md + scope ingestion to consumer surface (1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-04-18
+
+Context7 ingestion hygiene — separate dev-facing from consumer-facing.
+
+### Docs — Context7 scoping
+
+- **Hand-curated [`context7.md`](context7.md)** at repo root. Single
+  agent-focused primer covering install, quickstart, project layout,
+  notebook format, `jc.*` API, CLI surface, §10 contracts, and
+  architecture — with deep-link URLs to the RTD-hosted full versions.
+  Context7 was auto-generating one with Claude on each re-ingest; the
+  hand-curated file takes precedence and keeps the summary stable.
+- **[`context7.json`](context7.json) scoping**:
+  - `folders: ["docs/", "examples/"]` (was `["docs/"]`) — examples are
+    consumer-facing patterns and should be indexed.
+  - `excludeFolders` now covers `.claude`, `.github`, `scripts`,
+    `tests`, `docs/development`, `docs/spec` — dev-facing project
+    infrastructure that Context7 was indexing as if it were user
+    docs (the prior ingest surfaced 4 `.claude/skills/**/SKILL.md`
+    files meant for jellycell contributors, not downstream consumers).
+  - `excludeFiles: ["CLAUDE.md", "CONTRIBUTING.md", "CHANGELOG.md"]` —
+    root-level dev-facing files.
+  - `rules: [...]` — five short agent-guidance statements surfacing
+    the §10 contracts, the agent-guide entry point, and the monorepo
+    AGENTS.md policy.
+
+### Contracts (§10)
+
+- §10.1, §10.2, §10.3: all unchanged. Docs-only release.
+
 ## [1.1.0] — 2026-04-18
 
 Agentic-IDE reach + AI-friendly docs delivery. No code breaks anything
@@ -240,6 +270,7 @@ Each contract has a documented ceremony for changes — see [docs/development/re
 - `cache prune` removes manifests but not blobs. diskcache deduplicates content-addressed storage so disk impact is small; a ref-counted blob GC lands in a future release.
 - `jc.cache` argument hashing uses pickle. Unpicklable inputs raise clearly at call time; a JSON-default fallback can come later.
 
-[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/random-walks/jellycell/releases/tag/v1.1.1
 [1.1.0]: https://github.com/random-walks/jellycell/releases/tag/v1.1.0
 [1.0.0]: https://github.com/random-walks/jellycell/releases/tag/v1.0.0

--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,29 @@
 {
   "projectTitle": "jellycell",
-  "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer. Agent-friendly via `jellycell prompt` (stdout) or `jellycell prompt --write` (AGENTS.md + CLAUDE.md).",
-  "folders": ["docs/"],
-  "excludeFolders": ["docs/_build", "docs/apidocs"],
+  "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer.",
+  "folders": ["docs/", "examples/"],
+  "excludeFolders": [
+    ".claude",
+    ".github",
+    "scripts",
+    "tests",
+    "docs/_build",
+    "docs/apidocs",
+    "docs/development",
+    "docs/spec"
+  ],
+  "excludeFiles": [
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md"
+  ],
+  "rules": [
+    "Run `jellycell prompt` or `jellycell prompt --write` for the canonical agent guide — §10.3 stability contract.",
+    "Every CLI command supports `--json` with `schema_version: 1` (§10.1 contract).",
+    "Cache keys are content-addressed: sha256(normalized_source, sorted_dep_keys, env_hash, MINOR_VERSION). See `src/jellycell/cache/hashing.py` for the §10.2 contract.",
+    "Three §10 invariants gate major version bumps: --json schemas, cache key algorithm, and agent guide content.",
+    "One AGENTS.md at repo root covers every jellycell project underneath — `jellycell prompt --write` refuses to scatter inner duplicates without --force.",
+    "Full docs feed: https://jellycell.readthedocs.io/en/latest/llms-full.txt"
+  ],
   "previousVersions": []
 }

--- a/context7.md
+++ b/context7.md
@@ -1,0 +1,170 @@
+# jellycell
+
+**A living catalogue for reproducible analyses.** Plain-text `.py` notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer. Agent-friendly by design.
+
+- Docs: https://jellycell.readthedocs.io/
+- Repo: https://github.com/random-walks/jellycell
+- PyPI: https://pypi.org/project/jellycell/
+- Agent guide (canonical, §10.3): https://jellycell.readthedocs.io/en/latest/agent-guide.html
+- Full docs concat for agents: https://jellycell.readthedocs.io/en/latest/llms-full.txt
+
+## What it does
+
+A notebook is a plain `.py` file with a PEP-723 dependency header and jupytext percent-format cell markers. Run it with `jellycell run` — every cell's output is cached under `(normalized source, declared + detected deps, lockfile-aware env hash)`, so re-runs hit the cache instantly and editing a cell only re-executes that cell plus its dependents. Render it with `jellycell render` for a self-contained HTML catalogue, or serve it live with `jellycell view` (SSE reload on save).
+
+Consumers (humans and agents) get two surfaces: a CLI where every command supports `--json` with a versioned schema, and a `jc.*` runtime API for inline use inside cells.
+
+## Install
+
+```bash
+pip install jellycell            # CLI only
+pip install 'jellycell[server]'  # adds the live viewer
+```
+
+Requires Python ≥ 3.11.
+
+## Quickstart
+
+```bash
+jellycell init my-project
+cd my-project
+
+# (once per repo) drop AGENTS.md + CLAUDE.md so agentic tools read jellycell's guide
+jellycell prompt --write
+
+jellycell new tour                  # scaffold notebooks/tour.py
+# edit in your editor of choice
+jellycell run notebooks/tour.py     # first run executes; cached afterward
+jellycell render notebooks/tour.py  # writes site/tour.html
+jellycell view                      # live viewer (needs [server] extra)
+```
+
+## Project layout
+
+```
+my-project/
+├── jellycell.toml          # project config
+├── notebooks/              # .py notebooks (jupytext percent format)
+├── data/                   # input data, read by jc.load
+├── artifacts/              # outputs written by jc.save / jc.figure / jc.table
+├── site/                   # rendered HTML (jellycell render)
+├── manuscripts/            # narrative docs + tearsheets (markdown, committed)
+└── .jellycell/cache/       # content-addressed cache (gitignored)
+```
+
+**Monorepo**: one repo can hold several jellycell projects side by side. Put a single `AGENTS.md` at the **repo root** (not per project) — `jellycell prompt --write` detects outer AGENTS.md files and refuses to scatter inner duplicates without `--force`. See [project-layout.md](https://github.com/random-walks/jellycell/blob/main/docs/project-layout.md#multi-project--monorepo-pattern).
+
+## Notebook format
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pandas", "matplotlib"]
+#
+# [tool.jellycell]
+# timeout_seconds = 1800
+# ///
+
+# %% [markdown]
+# # Tour
+# One-paragraph description of what this notebook does.
+
+# %% tags=["jc.load", "name=raw"]
+import pandas as pd
+raw = pd.read_csv("data/sales.csv")
+
+# %% tags=["jc.step", "name=summary", "deps=raw"]
+import jellycell.api as jc
+summary = raw.describe()
+jc.save(summary, "artifacts/summary.json")
+jc.table(summary, caption="Sales summary")
+```
+
+- **PEP-723 script header**: `requires-python` + `dependencies` + optional `[tool.jellycell]` file-scope overrides (allow-listed keys: `project.name`, `run.kernel`, `run.timeout_seconds`).
+- **Cell tags**: `# %% tags=[...]` markers carry `cell-id`, `name`, `kind`, `deps`, `timeout_s`. Parsed by `jellycell.format`.
+- **Cell kinds** (declared via `kind=`): `load`, `setup`, `step`, `figure`, `table`. Drives lint and tearsheet rendering.
+
+## The `jc.*` API
+
+`import jellycell.api as jc`. Works inside a run (reads the live `RunContext`) and as a plain script (standalone mode).
+
+| Call | Purpose |
+| --- | --- |
+| `jc.load(path)` | Read input; registers an implicit dep edge on the producing cell via the artifact lineage index |
+| `jc.save(obj, path, caption=..., notes=..., tags=[...])` | Write an artifact; metadata lands on the `ArtifactRecord` in the cell manifest |
+| `jc.figure(fig=..., caption=..., notes=..., tags=[...])` | Save a matplotlib figure (auto-path via `[artifacts] layout`) |
+| `jc.table(df, caption=..., notes=..., tags=[...])` | Save a dataframe as markdown or parquet (layout-driven) |
+| `jc.deps("a", "b")` | Runtime-declared deps; AST-walked into the current cell's cache key |
+| `jc.cache` | Decorator that memoizes function calls via the content-addressed store |
+| `jc.path("name")` | Resolve an artifact path by producer name |
+| `jc.ctx` | Access the current `RunContext` (cell id, cache key, project paths) |
+
+## CLI commands
+
+- `jellycell init <path>` — scaffold a project.
+- `jellycell new <name>` — scaffold a notebook from the starter template.
+- `jellycell run <nb> [-m "msg"] [--force]` — execute end-to-end with caching; journal-aware.
+- `jellycell lint [--fix]` — policy-gated lint (layout, PEP-723 position, artifact paths, declared deps, cell output size).
+- `jellycell render [nb] [--standalone]` — build static HTML under `site/`.
+- `jellycell view` — live Starlette + SSE viewer (needs `[server]` extra).
+- `jellycell cache {list|prune|clear|rebuild-index}` — cache admin.
+- `jellycell export {ipynb|md|tearsheet} <nb>` — derived outputs.
+- `jellycell checkpoint {create|list|restore}` — reproducible `.tar.gz` snapshots.
+- `jellycell prompt [--write [DIR]]` — agent guide (stdout or `AGENTS.md` + `CLAUDE.md`).
+
+Every command supports `--json` for machine-readable output carrying `schema_version: 1`.
+
+## Stability contracts (§10)
+
+Three cross-cutting promises, each gated by a major version bump:
+
+1. **§10.1 `--json` schemas**. Every CLI command's JSON output has a pydantic model with `schema_version: int`. Adding optional fields is additive (minor); renaming / removing / re-typing is breaking (major + `schema_version` bump).
+2. **§10.2 Cache key algorithm**. `sha256(normalized_source, sorted_dep_keys, env_hash, MINOR_VERSION)`. Any change — normalization, inputs, composition — forces `MINOR_VERSION` bump and a major release (entire cache invalidates).
+3. **§10.3 Agent guide content**. Bytes emitted by `jellycell prompt` are stable across patches. Additive content is minor; breaking edits are major.
+
+Full ceremony: [docs/reference/contracts.md](https://github.com/random-walks/jellycell/blob/main/docs/reference/contracts.md).
+
+## Architecture — 8-layer dependency order
+
+```
+CLI → Server → Render → Run → API → Cache → Format → Paths+Config
+```
+
+Upper layers import only from lower. The `cache/` layer must not import from `run/`, `render/`, or `server/`. Full piggyback map + subpackage responsibilities: [docs/reference/architecture.md](https://github.com/random-walks/jellycell/blob/main/docs/reference/architecture.md).
+
+## Piggyback policy
+
+jellycell's value is composition. We depend on `jupytext`, `jupyter-client`, `nbformat`, `nbconvert` (output helpers only), `diskcache`, `markdown-it-py` + MyST plugins, `jinja2`, `starlette` + `watchfiles` + `sse-starlette`, `typer`, `pydantic`. We own the tag vocabulary, cache key derivation, manifest format, per-cell orchestration, page shell, dep graph, and agent guide.
+
+Before writing new code, check [docs/reference/architecture.md](https://github.com/random-walks/jellycell/blob/main/docs/reference/architecture.md) — the piggyback map lists every delegated responsibility.
+
+## Idiomatic patterns
+
+- **Name your cells**: `tags=["jc.step", "name=summary"]`. Named cells produce paths you can reference from `jc.load` / `jc.path` and appear in tearsheet navigation.
+- **Declare deps explicitly**: `deps=raw,config` in tags, or `jc.deps("raw", "config")` inline. Implicit dep edges from `jc.load(path)` still work; explicit wins on readability.
+- **Artifacts**: prefer explicit paths for shared outputs (`jc.save(x, "artifacts/key.json")`); use `jc.figure()` / `jc.table()` with `caption="..."` for path-less saves driven by `[artifacts] layout`.
+- **Captions matter**: caption / notes / tags on `jc.save` / `jc.figure` / `jc.table` flow into the tearsheet and the analysis journal.
+- **One AGENTS.md per repo**: not per jellycell project. `jellycell init` detects outer coverage; `jellycell prompt --write` warns before scattering inner overrides.
+- **Commit the journal** (`manuscripts/journal.md`) — reviewers (and you in six months) use it to answer "why did the numbers change?"
+- **Git-ignore** `.jellycell/` (cache) and `site/` (HTML); commit `notebooks/`, `data/` (small), `artifacts/` (outputs worth reviewing), `jellycell.toml`, `manuscripts/`.
+
+## Example projects
+
+The `examples/` folder in the repo has five fully-worked projects, each with a README, jellycell.toml, notebooks, and hand-authored manuscripts:
+
+- `minimal/` — bare-bones first touch.
+- `demo/` — analytics walkthrough (conversion numbers).
+- `paper/` — a paper draft with tearsheets + hand-authored writeup.
+- `timeseries/` — decomposition + forecasting with named cells + cross-notebook deps.
+- `ml-experiment/` — training run with model card.
+- `large-data/` — `[artifacts] layout = "by_notebook"` + `max_committed_size_mb` workflow (commit the digest, git-ignore the bulk).
+
+## Links for deeper reading
+
+- [Getting started](https://jellycell.readthedocs.io/en/latest/getting-started.html)
+- [File format](https://jellycell.readthedocs.io/en/latest/file-format.html)
+- [Project layout](https://jellycell.readthedocs.io/en/latest/project-layout.html)
+- [CLI reference](https://jellycell.readthedocs.io/en/latest/cli-reference.html)
+- [Agent guide (§10.3)](https://jellycell.readthedocs.io/en/latest/agent-guide.html)
+- [Architecture reference](https://jellycell.readthedocs.io/en/latest/reference/architecture.html)
+- [§10 Contracts](https://jellycell.readthedocs.io/en/latest/reference/contracts.html)

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.


### PR DESCRIPTION
## Summary

Context7 re-ingest log after the 1.1.0 merge surfaced two issues:

1. `Found 4 SKILL.md files, processing...` — our dev-facing `.claude/skills/*/SKILL.md` files (project-scoped Claude Code skills for jellycell contributors: phase-budget, piggyback-first, release-bump, spec-invariant) were being indexed as consumer-facing docs.
2. `context7.md does not exist, proceeding to generate/update it using Claude` — Context7 was auto-generating a summary on every re-ingest; a hand-curated file takes precedence and is stable.

## Changes

- **`context7.md`** (new, repo root): curated primer with install, quickstart, project layout, notebook format, `jc.*` API, CLI surface, §10 contracts, architecture, piggyback policy, idiomatic patterns, example projects. Deep-links to RTD for full docs.
- **`context7.json`**:
  - `folders: [\"docs/\", \"examples/\"]` — examples are consumer-facing patterns.
  - `excludeFolders`: adds `.claude`, `.github`, `scripts`, `tests`, `docs/development`, `docs/spec`.
  - `excludeFiles`: `CLAUDE.md`, `CONTRIBUTING.md`, `CHANGELOG.md` (schema: filename-only).
  - `rules`: 6 short agent-guidance statements.

Pattern mirrors [microsoft/skills/context7.json](https://github.com/microsoft/skills/blob/main/context7.json) which also excludes `.claude` to keep Claude Code skill infra out of the public index.

Patch bump 1.1.0 → 1.1.1 (docs-only; no code/contract change).

## Test plan

- [x] `make lint` clean
- [x] `make test` — 376 passed
- [x] `make release-check` builds `jellycell-1.1.1` wheel + sdist
- [x] `context7.json` validates against the [Context7 draft-07 schema](https://github.com/upstash/context7/blob/master/packages/mcp/schema/context7.json): description ≤200 chars, excludeFiles match `^[^/\\\\]+\$`, all rules in 5–200 char range
- [ ] Post-merge: Context7 re-ingest log should no longer show `Found 4 SKILL.md files` and should skip the Claude-generated summary step

🤖 Generated with [Claude Code](https://claude.com/claude-code)