### PR TITLE
chore(context7): add claim verification fields to context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,6 @@
 {
+  "url": "https://context7.com/random-walks/jellycell",
+  "public_key": "pk_RIxbmOCZyppRo9pw4GXFM",
   "projectTitle": "jellycell",
   "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer.",
   "folders": ["docs/", "examples/"],


### PR DESCRIPTION
## Summary

Adds the `url` + `public_key` verification fields to `context7.json` so Context7's \"Claim Library\" flow recognizes ownership of [context7.com/random-walks/jellycell](https://context7.com/random-walks/jellycell).

Two-line additive change — no version bump needed.

## Next steps (for you, after merge)

1. Open https://context7.com/random-walks/jellycell (or the claim page you were on)
2. Click **Claim Library** — Context7 will verify ownership by reading the `public_key` from the just-merged `context7.json`
3. Pick **context7.json** as the config source so future updates flow from the repo rather than the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)