### PR TITLE
fix(context7): minimize context7.json to just claim fields

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,31 +1,4 @@
 {
   "url": "https://context7.com/random-walks/jellycell",
-  "public_key": "pk_RIxbmOCZyppRo9pw4GXFM",
-  "projectTitle": "jellycell",
-  "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer.",
-  "folders": ["docs/", "examples/"],
-  "excludeFolders": [
-    ".claude",
-    ".github",
-    "scripts",
-    "tests",
-    "docs/_build",
-    "docs/apidocs",
-    "docs/development",
-    "docs/spec"
-  ],
-  "excludeFiles": [
-    "CLAUDE.md",
-    "CONTRIBUTING.md",
-    "CHANGELOG.md"
-  ],
-  "rules": [
-    "Run `jellycell prompt` or `jellycell prompt --write` for the canonical agent guide — §10.3 stability contract.",
-    "Every CLI command supports `--json` with `schema_version: 1` (§10.1 contract).",
-    "Cache keys are content-addressed: sha256(normalized_source, sorted_dep_keys, env_hash, MINOR_VERSION). See `src/jellycell/cache/hashing.py` for the §10.2 contract.",
-    "Three §10 invariants gate major version bumps: --json schemas, cache key algorithm, and agent guide content.",
-    "One AGENTS.md at repo root covers every jellycell project underneath — `jellycell prompt --write` refuses to scatter inner duplicates without --force.",
-    "Full docs feed: https://jellycell.readthedocs.io/en/latest/llms-full.txt"
-  ],
-  "previousVersions": []
+  "public_key": "pk_RIxbmOCZyppRo9pw4GXFM"
 }


### PR DESCRIPTION
## Summary

PR #4 committed the claim fields **alongside** the full config — which failed Context7's \"Claim Library\" verification:

> context7.json format is incorrect for claiming
> Requires \"url\" and \"public_key\". Known config fields are allowed, but unknown fields are not.

Research confirms: the claim endpoint rejects any fields outside \`{url, public_key}\` during verification, even schema-legitimate ones like \`rules\` and \`previousVersions\`. The UI's \"copy this JSON and commit it\" instruction is literal — the file must contain **only** those two fields while claiming.

## Change

\`context7.json\` is now exactly what the claim UI showed:

\`\`\`json
{
  \"url\": \"https://context7.com/random-walks/jellycell\",
  \"public_key\": \"pk_RIxbmOCZyppRo9pw4GXFM\"
}
\`\`\`

\`context7.md\` is unchanged — Context7 only validates the JSON during claim, not the markdown.

## Next steps (for you)

1. Merge this PR.
2. Go back to the Context7 claim UI and click **Claim Library** — verification should now succeed against the 2-field committed file.
3. Pick **context7.json** as the config source (so future parse settings flow from the repo).
4. I'll open a follow-up PR that restores the full config (\`folders\`, \`excludeFolders\`, \`excludeFiles\`, \`rules\`) once ownership is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)