### PR TITLE
docs(context7): restore scoped ingest config after claim (1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.1.2] — 2026-04-18
+
+### Docs — Context7 config restore
+
+- **`context7.json`** restored to the scoped-ingest config promised by
+  1.1.1 — `folders`, `excludeFolders` (skipping `.claude`, `tests`,
+  `docs/development`, `docs/spec`, etc.), `excludeFiles`, `rules`,
+  `previousVersions`. 1.1.1 had to minimize the file to just
+  `{url, public_key}` for Context7's library-claim verification
+  (strict `additionalProperties: false` on the claim endpoint);
+  after claim succeeded, the claim fields are no longer needed in
+  the committed file.
+
 ## [1.1.1] — 2026-04-18
 
 Context7 ingestion hygiene — separate dev-facing from consumer-facing.
@@ -270,7 +283,8 @@ Each contract has a documented ceremony for changes — see [docs/development/re
 - `cache prune` removes manifests but not blobs. diskcache deduplicates content-addressed storage so disk impact is small; a ref-counted blob GC lands in a future release.
 - `jc.cache` argument hashing uses pickle. Unpicklable inputs raise clearly at call time; a JSON-default fallback can come later.
 
-[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/random-walks/jellycell/releases/tag/v1.1.2
 [1.1.1]: https://github.com/random-walks/jellycell/releases/tag/v1.1.1
 [1.1.0]: https://github.com/random-walks/jellycell/releases/tag/v1.1.0
 [1.0.0]: https://github.com/random-walks/jellycell/releases/tag/v1.0.0

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,29 @@
 {
-  "url": "https://context7.com/random-walks/jellycell",
-  "public_key": "pk_RIxbmOCZyppRo9pw4GXFM"
+  "projectTitle": "jellycell",
+  "description": "Reproducible-analysis notebook tool: plain-text .py notebooks in jupytext percent format, content-addressed per-cell output cache, live HTML viewer.",
+  "folders": ["docs/", "examples/"],
+  "excludeFolders": [
+    ".claude",
+    ".github",
+    "scripts",
+    "tests",
+    "docs/_build",
+    "docs/apidocs",
+    "docs/development",
+    "docs/spec"
+  ],
+  "excludeFiles": [
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md"
+  ],
+  "rules": [
+    "Run `jellycell prompt` or `jellycell prompt --write` for the canonical agent guide — §10.3 stability contract.",
+    "Every CLI command supports `--json` with `schema_version: 1` (§10.1 contract).",
+    "Cache keys are content-addressed: sha256(normalized_source, sorted_dep_keys, env_hash, MINOR_VERSION). See `src/jellycell/cache/hashing.py` for the §10.2 contract.",
+    "Three §10 invariants gate major version bumps: --json schemas, cache key algorithm, and agent guide content.",
+    "One AGENTS.md at repo root covers every jellycell project underneath — `jellycell prompt --write` refuses to scatter inner duplicates without --force.",
+    "Full docs feed: https://jellycell.readthedocs.io/en/latest/llms-full.txt"
+  ],
+  "previousVersions": []
 }

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.


### PR DESCRIPTION
## Summary

Closes the loop on the Context7 claim: now that [context7.com/random-walks/jellycell](https://context7.com/random-walks/jellycell) is claimed, the committed \`context7.json\` goes back to the scoped-ingest shape 1.1.1 advertised.

Why strip \`url\` / \`public_key\`:

- **Schema**: Context7's [JSON Schema](https://github.com/upstash/context7/blob/master/packages/mcp/schema/context7.json) has \`additionalProperties: false\` and doesn't declare \`url\` or \`public_key\` in \`properties\` — the parse/re-ingest step will reject the whole file if they're present alongside the full config.
- **Empirical**: spot-checked three prominent claimed repos — \`upstash/ratelimit\`, \`angular/angular\`, \`microsoft/skills\` — none carry the claim fields in their committed \`context7.json\`.
- **Claim-time only**: the claim endpoint needs them during verification (that's why 1.1.1 had to minimize the file); post-claim, Context7's docs never explicitly say "remove them" but also never say "keep them," and the schema tips the scale toward strip.

Caveat: Context7's [troubleshooting doc](https://github.com/upstash/context7/blob/master/docs/howto/claiming-libraries.mdx) lists \"URL mismatch\" / \"public_key mismatch\" as live error states, which *could* mean they're rechecked on future reclaim flows. If a future re-verification ever trips that, we add them back — it's a two-line amendment.

\`context7.md\` is unchanged.

## Diff

- **\`context7.json\`**: restored to the full shape (\`projectTitle\`, \`description\`, \`folders\`, \`excludeFolders\`, \`excludeFiles\`, \`rules\`, \`previousVersions\`), no claim fields.
- **\`_version.py\`**: 1.1.1 → **1.1.2** (patch bump, docs-only).
- **\`CHANGELOG.md\`**: new \`[1.1.2]\` entry.

## Test plan

- [x] \`make lint\` clean
- [x] \`make release-check\` builds \`jellycell-1.1.2\` wheel + sdist; version string confirmed
- [x] \`context7.json\` has no \`url\` / \`public_key\` keys (verified)
- [ ] Post-merge: tag \`v1.1.2\` → PyPI publishes via OIDC, Context7 re-ingests with the scoped config (log should show only \`docs/\` + \`examples/\`, no \`.claude/skills/**\` SKILL.md entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)