### PR TITLE
feat(prompt): --nested flag + polyglot docs overhaul (1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-04-19
+
+Polyglot UX fixes from real-world dogfood: a new `--nested` flag that
+removes a `--force` misnomer, plus docs that actually describe the
+two legitimate AGENTS.md placements instead of framing one as a trap.
+
+### Features — `jellycell prompt --write --nested`
+
+- **New `--nested` flag**. Acknowledges an outer `AGENTS.md` detected
+  in an ancestor and writes an intentional inner override at the
+  target without needing `--force`. Still refuses to clobber an
+  existing target file (use `--force` for that). Semantics:
+
+  | Target state                                      | Flag       |
+  | ------------------------------------------------- | ---------- |
+  | No outer, no existing target file                 | (none)     |
+  | Outer AGENTS.md exists, no existing inner file    | `--nested` |
+  | Existing target file (any scope)                  | `--force`  |
+  | Outer AGENTS.md + existing inner target           | `--nested --force` |
+
+  Before 1.3.0, adopting the polyglot "nested" layout required
+  `--force`, which semantically implied "clobber everything" and
+  lumped two distinct intents (acknowledge outer / overwrite target)
+  into one flag. `--nested` separates them.
+
+- **`PromptWriteReport.nested: bool`** field added to the `--json`
+  output (§10.1 additive — no `schema_version` bump). `true` when
+  `--nested` was passed AND an outer `AGENTS.md` was detected;
+  `false` otherwise (including on `--force`-only writes that
+  happened to suppress the same check).
+
+- **Error message on outer-detection** now surfaces both escape
+  hatches: "Re-run with `--nested` to intentionally add an inner
+  override for this subtree, or `--force` to bypass all checks."
+
+### Docs — polyglot patterns
+
+- **`docs/project-layout.md` polyglot subsection** rewritten around
+  two defensible AGENTS.md placements:
+  - *Pattern A (recommended for polyglot)* — `AGENTS.md` at the
+    Python subtree (`packages/python-showcase/AGENTS.md`) alongside
+    an outer repo-wide `AGENTS.md` at the git root. Agents compose
+    both per the AGENTS.md spec.
+  - *Pattern B* — single `AGENTS.md` at the git root.
+
+  Use `uv --directory` (cd's in) + `--nested` for Pattern A; use
+  `uv --project` (stays in cwd) for Pattern B. Previous 1.2.0
+  wording framed `uv --directory` as a trap, which was only correct
+  for Pattern B.
+- **pnpm wrapper recipes** added for the `--project` Typer-global
+  footgun. Jellycell's `--project <path>` must precede the
+  subcommand, which conflicts with pnpm's natural "positional arg
+  at the end" script shape. A tiny `bash -c '… --project "$1"
+  <subcmd> "${@:2}"' --` wrapper bridges it; the new subsection
+  shows five ready-to-paste scripts (`showcase:run`, `showcase:init`,
+  `showcase:render`, `showcase:view`, `showcase:lint`).
+- **"If you already have an AGENTS.md" note** documents the current
+  clobber-or-hand-merge reality plus the `AGENTS.jellycell.md`
+  sibling-file workaround. Previews a future `jellycell prompt
+  --append` flag using Next.js-style `<!-- BEGIN:jellycell -->` /
+  `<!-- END:jellycell -->` marker blocks (that's the emerging
+  community convention; agents.md spec is silent). Shipping the
+  append flag itself is a future minor — this release just
+  documents intent.
+- **`docs/cli-reference.md`** — `--nested` documented with the
+  full flag table.
+- **`docs/agent-guide.md`** — "Single-project vs monorepo"
+  section updated to mention `--nested` (§10.3 additive; snapshot
+  regenerated from 11915 → 12140 bytes; canonical headers
+  preserved).
+- **`examples/monorepo/README.md`** polyglot section updated to
+  show `--nested` in the Pattern A command.
+
+### Contracts (§10)
+
+- §10.1 `--json` schemas: **additive** — `PromptWriteReport` gains
+  `nested: bool` field. No `schema_version` bump. Snapshot
+  regenerated.
+- §10.2 cache key: unchanged. `MINOR_VERSION` stays at 1.
+- §10.3 agent guide content: **additive** — one paragraph added to
+  the existing "Single-project vs monorepo" section. Snapshot
+  regenerated.
+
 ## [1.2.0] — 2026-04-19
 
 Monorepo patterns — one Python env, multiple jellycell projects — now
@@ -328,7 +411,8 @@ Each contract has a documented ceremony for changes — see [docs/development/re
 - `cache prune` removes manifests but not blobs. diskcache deduplicates content-addressed storage so disk impact is small; a ref-counted blob GC lands in a future release.
 - `jc.cache` argument hashing uses pickle. Unpicklable inputs raise clearly at call time; a JSON-default fallback can come later.
 
-[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/random-walks/jellycell/releases/tag/v1.3.0
 [1.2.0]: https://github.com/random-walks/jellycell/releases/tag/v1.2.0
 [1.1.2]: https://github.com/random-walks/jellycell/releases/tag/v1.1.2
 [1.1.1]: https://github.com/random-walks/jellycell/releases/tag/v1.1.1

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -42,11 +42,13 @@ each with its own `jellycell.toml` in a subdirectory. Caches, artifacts, and
 `site/` output stay scoped to each project's subtree; one `AGENTS.md` at the
 root covers every project inside. `jellycell init <subdir>` and
 `jellycell prompt --write <subdir>` are monorepo-aware — they detect an outer
-`AGENTS.md` and refuse to scatter duplicates without `--force`. From the
-monorepo root, run commands via `jellycell run <subdir>/notebooks/foo.py`
-or `jellycell --project <subdir> render`. See
-[project-layout](project-layout.md#multi-project--monorepo-pattern) for the
-full convention.
+`AGENTS.md` and refuse to scatter duplicates by default. Pass `--nested` for
+intentional inner scoping (polyglot pattern: jellycell's guide at the Python
+subtree, repo-wide `AGENTS.md` at the git root) or `--force` to bypass all
+checks. From the monorepo root, run commands via
+`jellycell run <subdir>/notebooks/foo.py` or `jellycell --project <subdir>
+render`. See [project-layout](project-layout.md#multi-project--monorepo-pattern)
+for the full convention including polyglot patterns and pnpm script recipes.
 
 ## File format
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -152,30 +152,44 @@ Emit the canonical [agent guide](agent-guide.md) to stdout, or install
 it as `AGENTS.md` + `CLAUDE.md` with `--write`.
 
 ```bash
-jellycell prompt | pbcopy                    # stdout — pipe into your agent
-jellycell prompt --write                     # drop AGENTS.md + CLAUDE.md in cwd
-jellycell prompt --write /path/to/repo-root  # target a specific directory
-jellycell prompt --write --agents-only       # skip the CLAUDE.md stub
-jellycell prompt --write --force             # overwrite existing files
+jellycell prompt | pbcopy                           # stdout — pipe into your agent
+jellycell prompt --write                            # drop AGENTS.md + CLAUDE.md in cwd
+jellycell prompt --write /path/to/repo-root         # target a specific directory
+jellycell prompt --write --agents-only              # skip the CLAUDE.md stub
+jellycell prompt --write --nested                   # intentional inner nesting (polyglot)
+jellycell prompt --write --force                    # overwrite existing files
 ```
 
 Flags:
 
-- `--write` — switch from stdout emission to disk-install mode. Without
-  it, the command behaves identically to pre-1.1 (§10.3 stability
-  contract preserves the stdout bytes).
-- `--force` — required to overwrite an existing `AGENTS.md` or
-  `CLAUDE.md`, or to write an inner override when an outer `AGENTS.md`
-  is detected in an ancestor directory.
+- `--write` — switch from stdout emission to disk-install mode.
+  Without it, the command behaves identically to pre-1.1 (the §10.3
+  stability contract preserves the stdout bytes).
+- `--nested` — acknowledge an outer `AGENTS.md` detected in an
+  ancestor directory and write an intentional inner override to the
+  target. Bypasses the outer-detection refuse only; still refuses to
+  clobber an existing target file without `--force`. Use this when
+  adopting the polyglot Pattern A layout (jellycell's guide at the
+  Python subtree root, repo-wide `AGENTS.md` at the git root).
+- `--force` — bypass every check: outer-AGENTS-detection refuse *and*
+  overwrite an existing `AGENTS.md` / `CLAUDE.md` at the target.
 - `--agents-only` — write only `AGENTS.md`, skip the `CLAUDE.md` stub.
   Useful when Claude Code isn't in the mix.
+
+| Target state                                       | Flag needed            |
+| -------------------------------------------------- | ---------------------- |
+| No outer AGENTS.md, no existing target file        | (none)                 |
+| Outer AGENTS.md exists, no existing inner file     | `--nested`             |
+| Existing target file (any scope)                   | `--force`              |
+| Outer AGENTS.md exists + existing inner target     | `--nested --force`     |
 
 **Monorepo safety**: `--write` walks up the directory tree looking for
 an existing `AGENTS.md` (stopping at the first `.git/` directory,
 `$HOME`, or filesystem root). If one is found in an ancestor, the
-command refuses to write an inner duplicate and prints a hint pointing
-at `--force`. See [project-layout.md](project-layout.md#multi-project--monorepo-pattern)
-for the recommended monorepo layout.
+command refuses by default and prints a hint pointing at `--nested`
+(for intentional inner scoping) or `--force` (to bypass all checks).
+See [project-layout.md](project-layout.md#multi-project--monorepo-pattern)
+for the recommended monorepo layouts.
 
 **What's in AGENTS.md**: the same content as `jellycell prompt` stdout,
 with the MyST `:::{important}` directive rewritten as a plain-markdown

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -106,12 +106,119 @@ Nothing about jellycell's walk-up is Python-specific. If your Python
 package lives deep inside a pnpm / turbo / Node repo —
 `packages/python-showcase/showcase-marketing/` — jellycell works
 identically, provided `AGENTS.md` sits somewhere at or above the
-project dir and at or below the git root. Shell out through
-`uv --directory packages/python-showcase run jellycell …` from your
-pnpm scripts.
+project dir and at or below the git root. You have two defensible
+patterns for where `AGENTS.md` goes; pick based on your repo shape.
+
+**Pattern A — AGENTS.md at the Python subtree root** (recommended for
+polyglot). `packages/python-showcase/AGENTS.md` scopes jellycell's
+~12 KB §10.3 guide to the subtree where it's relevant. An outer
+repo-wide `AGENTS.md` can still sit at the git root covering
+monorepo-structure, TypeScript conventions, etc. — agents compose
+them per the AGENTS.md spec (Codex concatenates outer→inner; Cursor,
+GitLab Duo, and others read both). When an outer `AGENTS.md` is
+present, tell jellycell the nesting is intentional with `--nested`:
+
+```bash
+# Writes AGENTS.md + CLAUDE.md at packages/python-showcase/.
+# `uv --directory` cd's into that dir before running, which is exactly
+# what we want for Pattern A. `--nested` says "I know there's an outer
+# AGENTS.md at the repo root, this is a deliberate inner override."
+uv --directory packages/python-showcase run jellycell prompt --write --nested
+```
+
+`--nested` bypasses the outer-AGENTS-detection refuse *only*; it still
+refuses to clobber an existing target file (use `--force` to refresh
+an existing inner AGENTS.md).
+
+**Pattern B — AGENTS.md at the git root** (good for Python-first
+repos or when you want a single source of truth). `uv --project`
+points uv at the Python package's env *without* changing cwd, so
+`jellycell prompt --write` lands `AGENTS.md` at the repo root:
+
+```bash
+# cwd stays at the monorepo root; AGENTS.md + CLAUDE.md land there.
+# No --nested needed because there's no outer AGENTS.md to compose with.
+uv --project packages/python-showcase run jellycell prompt --write
+```
+
+The `uv --directory` vs `uv --project` knob is what controls
+cwd-dependent behavior (`jellycell prompt --write` without a path
+argument; `jellycell init <name>` with a relative name). Once you've
+chosen a pattern, day-to-day `run` / `render` / `view` invocations
+work the same under either:
+
+```bash
+# Notebook path anchored to the Python package root — same under A or B:
+uv --directory packages/python-showcase run jellycell run showcase-marketing/notebooks/tour.py
+```
+
+Flag summary for `jellycell prompt --write`:
+
+| Target state                                      | Flag needed |
+| ------------------------------------------------- | ----------- |
+| No outer, no existing target file                 | (none)      |
+| Outer AGENTS.md exists, no existing inner file    | `--nested`  |
+| Existing target file (any scope)                  | `--force`   |
+| Outer AGENTS.md exists + existing inner file      | `--nested --force` |
+
+### pnpm wrapper recipes
+
+Jellycell's `--project <path>` is a Typer **global** option — it must
+precede the subcommand (`jellycell --project X render`, not
+`jellycell render --project X`). That's awkward to wire through pnpm
+scripts that accept a positional showcase name at the end. A tiny bash
+wrapper bridges the gap:
+
+```json
+{
+  "scripts": {
+    "showcase:run":    "uv --project packages/python-showcase run jellycell run",
+    "showcase:init":   "uv --project packages/python-showcase run jellycell init",
+    "showcase:render": "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" render \"${@:2}\"' --",
+    "showcase:view":   "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" view \"${@:2}\"' --",
+    "showcase:lint":   "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" lint \"${@:2}\"' --"
+  }
+}
+```
+
+Then from the repo root:
+
+```bash
+pnpm showcase:run showcase-marketing/notebooks/tour.py
+pnpm showcase:render showcase-marketing               # "$1" → --project showcase-marketing
+pnpm showcase:view   showcase-churn                   # live viewer on :5179
+pnpm showcase:lint   showcase-marketing --fix         # extras flow through
+```
+
+`showcase:run` and `showcase:init` don't need the wrapper because
+their first argument already locates the project (a notebook path or a
+target directory).
 
 See [`examples/monorepo/`](https://github.com/random-walks/jellycell/tree/main/examples/monorepo)
 for a minimal, runnable reference.
+
+### If you already have an AGENTS.md
+
+`jellycell prompt --write` **refuses to clobber** an existing
+`AGENTS.md` or `CLAUDE.md` at the target. `--force` is the only
+bypass today; see the flag table above. There's no in-file merge
+primitive yet.
+
+- **Polyglot, want jellycell's guide inside the Python subtree** —
+  `--nested` (no outer-detection refuse) plus `--force` (only if an
+  inner `AGENTS.md` already exists). The outer root `AGENTS.md`
+  stays untouched; composition happens at agent-read time.
+- **Single-root pattern, existing hand-written AGENTS.md** — merge
+  by hand: back up your file, run `--force`, paste your repo-
+  specific preamble back. Or keep your hand-written `AGENTS.md` and
+  write jellycell's to a sibling `AGENTS.jellycell.md` that your
+  main file references with a plain markdown link.
+
+A future release will add `jellycell prompt --append` with Next.js-
+style `<!-- BEGIN:jellycell … -->` / `<!-- END:jellycell … -->`
+marker blocks, idempotently refreshed in place. That removes the
+`--force`-or-clobber tradeoff for mixed AGENTS.md files. Track /
+influence at [github.com/random-walks/jellycell](https://github.com/random-walks/jellycell).
 
 ## Full `jellycell.toml` reference
 

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -121,12 +121,39 @@ Git-ignore (this root `.gitignore` covers every showcase):
 
 ## Polyglot monorepos
 
-Nothing about jellycell's walk-up is Python-specific. If you drop this
-structure deeper — `packages/python-showcase/showcase-marketing/` —
-inside a pnpm/turbo/Next.js repo, jellycell still works identically,
-provided `AGENTS.md` sits at the outer git root. Shell out through
-`uv --directory packages/python-showcase run jellycell --project
-<showcase> …` from your pnpm scripts.
+If you drop this structure deeper — `packages/python-showcase/
+showcase-marketing/` — inside a pnpm/turbo/Next.js repo, you choose
+between two AGENTS.md placements:
+
+- **Nested** (recommended) — `packages/python-showcase/AGENTS.md`
+  scopes jellycell's ~12 KB guide to the Python subtree; the outer
+  repo can still have its own `AGENTS.md` at the git root covering
+  TypeScript / monorepo conventions. Agents compose both per the
+  AGENTS.md spec.
+- **Single root** — one `AGENTS.md` at the git root covers
+  everything. Simpler but pollutes the root with Python-specific
+  rules.
+
+The `uv --directory` vs `uv --project` knob controls cwd-dependent
+commands like `jellycell prompt --write`. When an outer `AGENTS.md`
+exists at the git root and you want a nested inner one, pass
+`--nested` to skip the scatter-prevention refuse:
+
+```bash
+# Nested: writes AGENTS.md at packages/python-showcase/ alongside an
+# outer root AGENTS.md. --directory cd's in; --nested acknowledges
+# the outer.
+uv --directory packages/python-showcase run jellycell prompt --write --nested
+
+# Root: writes a single AGENTS.md at the git root. --project stays
+# in cwd; no --nested needed.
+uv --project packages/python-showcase run jellycell prompt --write
+```
+
+Full write-up:
+[project-layout.md#polyglot-monorepos](https://jellycell.readthedocs.io/en/latest/project-layout.html#polyglot-monorepos)
+including the complete flag table and pnpm-script wrapper recipes for
+the `--project`-takes-a-showcase-name ergonomics.
 
 ## See also
 

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.

--- a/src/jellycell/cli/commands/prompt.py
+++ b/src/jellycell/cli/commands/prompt.py
@@ -48,6 +48,7 @@ class PromptWriteReport(BaseModel):
     written: list[str]
     skipped: list[str]
     outer_agents_md: str | None = None
+    nested: bool = False
 
 
 def _read_guide() -> str:
@@ -119,6 +120,14 @@ def prompt(
         False, "--write", help="Write AGENTS.md + CLAUDE.md to DIRECTORY instead of stdout."
     ),
     force: bool = typer.Option(False, "--force", help="Overwrite existing AGENTS.md / CLAUDE.md."),
+    nested: bool = typer.Option(
+        False,
+        "--nested",
+        help=(
+            "Acknowledge an outer AGENTS.md and write an intentional inner override "
+            "without --force. Still refuses to clobber an existing target file."
+        ),
+    ),
     agents_only: bool = typer.Option(
         False, "--agents-only", help="Skip the CLAUDE.md stub (AGENTS.md only)."
     ),
@@ -131,10 +140,12 @@ def prompt(
         typer.echo(_read_guide(), nl=False)
         return
     target = (directory or Path.cwd()).resolve()
-    _do_write(opts, target, force=force, agents_only=agents_only)
+    _do_write(opts, target, force=force, nested=nested, agents_only=agents_only)
 
 
-def _do_write(opts: GlobalOptions, target: Path, *, force: bool, agents_only: bool) -> None:
+def _do_write(
+    opts: GlobalOptions, target: Path, *, force: bool, nested: bool, agents_only: bool
+) -> None:
     if not target.is_dir():
         _fail(opts, f"{target} is not a directory.")
 
@@ -142,12 +153,13 @@ def _do_write(opts: GlobalOptions, target: Path, *, force: bool, agents_only: bo
     claude_path = target / "CLAUDE.md"
 
     outer = _find_outer_agents_md(target)
-    if outer is not None and not force:
+    if outer is not None and not force and not nested:
         _fail(
             opts,
             f"found AGENTS.md at {outer} — agentic tools compose nested "
             "AGENTS.md files, so the outer one already applies here. "
-            "Re-run with --force to write an inner override for this subdirectory.",
+            "Re-run with --nested to intentionally add an inner override "
+            "for this subtree, or --force to bypass all checks.",
         )
 
     conflicts: list[Path] = []
@@ -178,6 +190,7 @@ def _do_write(opts: GlobalOptions, target: Path, *, force: bool, agents_only: bo
         written=written,
         skipped=skipped,
         outer_agents_md=str(outer) if outer else None,
+        nested=nested and outer is not None,
     )
     if opts.json_output:
         typer.echo(report.model_dump_json())
@@ -187,8 +200,9 @@ def _do_write(opts: GlobalOptions, target: Path, *, force: bool, agents_only: bo
         for path in skipped:
             _console.print(f"[dim]skipped[/dim] {path}")
         if outer is not None:
+            prefix = "[cyan]nested:[/cyan]" if nested else "[yellow]note:[/yellow]"
             _console.print(
-                f"[yellow]note:[/yellow] outer AGENTS.md at {outer} — "
+                f"{prefix} outer AGENTS.md at {outer} — "
                 "inner override wins for this subtree per the AGENTS.md spec."
             )
 

--- a/tests/integration/test_json_schemas/prompt_write.yml
+++ b/tests/integration/test_json_schemas/prompt_write.yml
@@ -1,3 +1,4 @@
+nested: bool
 outer_agents_md: 'null'
 schema_version: int
 skipped:

--- a/tests/integration/test_prompt_write.py
+++ b/tests/integration/test_prompt_write.py
@@ -91,8 +91,46 @@ class TestOuterAgentsDetection:
         result = runner.invoke(app, ["prompt", "--write", str(inner)])
         assert result.exit_code == 1
         assert "found AGENTS.md at" in result.output
+        # Error message surfaces both escape hatches.
+        assert "--nested" in result.output
         assert "--force" in result.output
         assert not (inner / "AGENTS.md").exists()
+
+    def test_nested_bypasses_outer_detection_without_force(self, tmp_path: Path) -> None:
+        """--nested is the polite "I know, intentional inner scope" flag."""
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub-project"
+        inner.mkdir()
+        result = runner.invoke(app, ["prompt", "--write", "--nested", str(inner)])
+        assert result.exit_code == 0, result.output
+        assert (inner / "AGENTS.md").is_file()
+        # Outer untouched — --nested writes the inner override, nothing more.
+        assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "# outer"
+        # Console output flags this as intentional nesting (not a scatter-warning).
+        assert "nested:" in result.output
+
+    def test_nested_still_refuses_existing_target_file(self, tmp_path: Path) -> None:
+        """--nested bypasses outer-detection only — overwrite protection still applies."""
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub-project"
+        inner.mkdir()
+        (inner / "AGENTS.md").write_text("# custom inner", encoding="utf-8")
+        result = runner.invoke(app, ["prompt", "--write", "--nested", str(inner)])
+        assert result.exit_code == 1
+        assert "already exist" in result.output
+        # Custom inner content preserved.
+        assert (inner / "AGENTS.md").read_text(encoding="utf-8") == "# custom inner"
+
+    def test_nested_plus_force_overwrites_inner(self, tmp_path: Path) -> None:
+        """--nested + --force is the full polyglot refresh path."""
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub-project"
+        inner.mkdir()
+        (inner / "AGENTS.md").write_text("# stale inner", encoding="utf-8")
+        result = runner.invoke(app, ["prompt", "--write", "--nested", "--force", str(inner)])
+        assert result.exit_code == 0, result.output
+        assert (inner / "AGENTS.md").read_text(encoding="utf-8").startswith("# Agent guide")
+        assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "# outer"
 
     def test_force_overrides_outer_warning(self, tmp_path: Path) -> None:
         (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
@@ -153,3 +191,16 @@ class TestJsonOutput:
         report = json.loads(result.output.strip().splitlines()[-1])
         assert report["outer_agents_md"] is not None
         assert report["outer_agents_md"].endswith("AGENTS.md")
+        # --force bypasses the outer-detection check but is NOT the same as --nested,
+        # which is about intent. `nested` only flags true when --nested was passed.
+        assert report["nested"] is False
+
+    def test_json_flags_nested_true_when_intentional(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# outer", encoding="utf-8")
+        inner = tmp_path / "sub"
+        inner.mkdir()
+        result = runner.invoke(app, ["--json", "prompt", "--write", "--nested", str(inner)])
+        assert result.exit_code == 0, result.output
+        report = json.loads(result.output.strip().splitlines()[-1])
+        assert report["outer_agents_md"] is not None
+        assert report["nested"] is True

--- a/tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml
+++ b/tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml
@@ -3,6 +3,6 @@ contains_canonical_headers:
   cli_commands_section: true
   invariants_section: true
   jc_api_section: true
-length: 11915
-sha256_first_32: 5fb1025ed781e2bfa40a97b720a51f2d
+length: 12140
+sha256_first_32: d572a98c36cccb98a43da498b12e3a05
 starts_with: '# Agent guide'


### PR DESCRIPTION
## Summary

Dogfood from a real polyglot monorepo (pnpm + turbo + uv) surfaced two paper-cuts in how \`jellycell prompt --write\` handles nested AGENTS.md composition. Fixes them properly instead of papering over in docs — 1.2.0 shipped hours ago, no external users, better to get the API right now.

## New flag: \`--nested\`

Before 1.3.0, the legitimate polyglot layout (jellycell's guide at \`packages/python-showcase/AGENTS.md\` alongside a repo-wide outer \`AGENTS.md\` at the git root) required \`--force\` to bypass the outer-AGENTS-detection refuse. That lumped two distinct intents into one flag. \`--nested\` separates them:

| Target state | Flag |
|---|---|
| No outer, no existing target file | (none) |
| Outer AGENTS.md exists, no existing inner file | \`--nested\` |
| Existing target file (any scope) | \`--force\` |
| Outer + existing inner target | \`--nested --force\` |

- \`PromptWriteReport.nested: bool\` added to \`--json\` output. §10.1 additive; no \`schema_version\` bump.
- Error message now surfaces both escape hatches.

## Polyglot docs overhaul

- **\`docs/project-layout.md\`** polyglot subsection rewritten around two defensible AGENTS.md placements (Pattern A nested + Pattern B root). Previous 1.2.0 wording framed \`uv --directory\` as a trap; it's actually the right tool for Pattern A.
- **pnpm wrapper recipes** added for the \`--project\`-must-precede-subcommand footgun. Five ready-to-paste scripts.
- **\"If you already have an AGENTS.md\" note** — hand-merge and sibling-file workarounds; previews a future \`--append\` with Next.js-style marker blocks.
- **\`docs/cli-reference.md\`** — full \`--nested\` documentation + flag-combo table.
- **\`docs/agent-guide.md\`** — \"Single-project vs monorepo\" mentions \`--nested\` (§10.3 additive; snapshot regenerated 11915 → 12140 bytes; canonical headers preserved).
- **\`examples/monorepo/README.md\`** — Pattern A command uses \`--nested\`.

## Tests

4 new + 2 updated covering the full flag matrix, plus JSON + snapshot regen.

## Version

1.2.0 → **1.3.0** (new CLI flag + new JSON field = minor).

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` — 380 passed (was 376 in 1.2.0)
- [x] \`make docs-build\` strict
- [x] \`make release-check\` builds \`jellycell-1.3.0\` wheel + sdist
- [x] Live smoke — full matrix: refuse → --nested writes → second --nested refuses on existing → --nested --force overwrites → --json flags nested correctly
- [ ] Post-merge: tag \`v1.3.0\` → PyPI via OIDC; then relay a prompt to the blaise-website agent so it can update to the cleaner flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)