### PR TITLE
docs(polyglot): pnpm wrappers use uv --directory (1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-04-19
+
+Docs patch — fixes a self-contradicting pnpm wrapper recipe
+surfaced by a real polyglot dogfood (thanks to the blaise-website
+agent for the clean repro).
+
+### Docs — pnpm wrapper recipes use `uv --directory`
+
+The `docs/project-layout.md` *pnpm wrapper recipes* block in 1.3.0
+shipped every script using `uv --project packages/python-showcase`,
+but the usage examples that follow used `uv --directory`. For any
+showcase nested under `packages/python-showcase/` (the whole point
+of the section) `uv --project` keeps cwd at the repo root, so
+`pnpm showcase:run showcase-marketing/notebooks/tour.py` resolves
+against the repo root — **fails with "No jellycell.toml found"**.
+
+`uv --directory <path>` cd's into `<path>` before running, so
+relative showcase paths resolve under the Python package root —
+which is what every `showcase:*` script wants. Every wrapper now
+uses `uv --directory`. A short "why" paragraph explains when
+`uv --project` is still the right call (the one-shot
+`jellycell prompt --write` under Pattern B, where you want cwd
+pinned at the monorepo root so AGENTS.md lands there).
+
+Reproduce the old bug:
+
+```bash
+cd /tmp/anyrepo && git init -q
+uv init --package packages/python-showcase
+mkdir -p packages/python-showcase/foo/notebooks
+uv --project packages/python-showcase run jellycell run foo/notebooks/x.py
+# → "No jellycell.toml found walking up from /tmp/anyrepo/foo/notebooks/x.py"
+```
+
+No code changes. No contracts touched.
+
+### Contracts (§10)
+
+- All unchanged. Docs-only patch.
+
 ## [1.3.0] — 2026-04-19
 
 Polyglot UX fixes from real-world dogfood: a new `--nested` flag that
@@ -411,7 +451,8 @@ Each contract has a documented ceremony for changes — see [docs/development/re
 - `cache prune` removes manifests but not blobs. diskcache deduplicates content-addressed storage so disk impact is small; a ref-counted blob GC lands in a future release.
 - `jc.cache` argument hashing uses pickle. Unpicklable inputs raise clearly at call time; a JSON-default fallback can come later.
 
-[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/random-walks/jellycell/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/random-walks/jellycell/releases/tag/v1.3.1
 [1.3.0]: https://github.com/random-walks/jellycell/releases/tag/v1.3.0
 [1.2.0]: https://github.com/random-walks/jellycell/releases/tag/v1.2.0
 [1.1.2]: https://github.com/random-walks/jellycell/releases/tag/v1.1.2

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -167,16 +167,23 @@ Jellycell's `--project <path>` is a Typer **global** option — it must
 precede the subcommand (`jellycell --project X render`, not
 `jellycell render --project X`). That's awkward to wire through pnpm
 scripts that accept a positional showcase name at the end. A tiny bash
-wrapper bridges the gap:
+wrapper bridges the gap.
+
+Use `uv --directory packages/python-showcase` (cd's in) in every
+wrapper — **not** `uv --project`. A showcase name like
+`showcase-marketing` only resolves correctly when cwd is the Python
+package root; `uv --project` keeps cwd at the repo root, where
+`showcase-marketing` would resolve to `<repo-root>/showcase-marketing`
+and fail with *No jellycell.toml found*.
 
 ```json
 {
   "scripts": {
-    "showcase:run":    "uv --project packages/python-showcase run jellycell run",
-    "showcase:init":   "uv --project packages/python-showcase run jellycell init",
-    "showcase:render": "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" render \"${@:2}\"' --",
-    "showcase:view":   "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" view \"${@:2}\"' --",
-    "showcase:lint":   "bash -c 'uv --project packages/python-showcase run jellycell --project \"$1\" lint \"${@:2}\"' --"
+    "showcase:run":    "uv --directory packages/python-showcase run jellycell run",
+    "showcase:init":   "uv --directory packages/python-showcase run jellycell init",
+    "showcase:render": "bash -c 'uv --directory packages/python-showcase run jellycell --project \"$1\" render \"${@:2}\"' --",
+    "showcase:view":   "bash -c 'uv --directory packages/python-showcase run jellycell --project \"$1\" view \"${@:2}\"' --",
+    "showcase:lint":   "bash -c 'uv --directory packages/python-showcase run jellycell --project \"$1\" lint \"${@:2}\"' --"
   }
 }
 ```
@@ -190,9 +197,16 @@ pnpm showcase:view   showcase-churn                   # live viewer on :5179
 pnpm showcase:lint   showcase-marketing --fix         # extras flow through
 ```
 
-`showcase:run` and `showcase:init` don't need the wrapper because
-their first argument already locates the project (a notebook path or a
-target directory).
+`showcase:run` and `showcase:init` don't need the bash-c wrapper
+because their first positional argument already locates the project
+(a notebook path relative to the Python package root, or a target
+directory for `init`).
+
+`uv --project` is still the right choice for the one-shot
+`jellycell prompt --write` under Pattern B (single root AGENTS.md) —
+there you *want* cwd pinned at the monorepo root so the file lands
+there. It's just a bad fit for day-to-day wrappers that accept
+relative showcase paths.
 
 See [`examples/monorepo/`](https://github.com/random-walks/jellycell/tree/main/examples/monorepo)
 for a minimal, runnable reference.

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.


### PR DESCRIPTION
## Summary

Caught by the blaise-website dogfood agent: 1.3.0's pnpm wrapper recipes in \`docs/project-layout.md\` self-contradict. The JSON block uses \`uv --project packages/python-showcase\` everywhere; the usage examples immediately below use \`uv --directory\`. For any showcase nested under \`packages/python-showcase/\` (the whole point of the section), \`uv --project\` keeps cwd at the repo root and \`pnpm showcase:run showcase-marketing/notebooks/tour.py\` fails with *No jellycell.toml found*.

All five scripts now use \`uv --directory\` (cd's in), matching the usage examples. A short paragraph above the block explains the semantics and flags \`uv --project\` as the right choice for the one-shot \`jellycell prompt --write\` under Pattern B (where cwd pinned at repo root is desired).

## Repro (demonstrating the old bug)

\`\`\`bash
cd /tmp/anyrepo && git init -q
uv init --package packages/python-showcase
mkdir -p packages/python-showcase/foo/notebooks
uv --project packages/python-showcase run jellycell run foo/notebooks/x.py
# → \"No jellycell.toml found walking up from /tmp/anyrepo/foo/notebooks/x.py\"
\`\`\`

Swapping to \`uv --directory\`: ✅ works.

## Scope

Docs-only patch, 1.3.0 → **1.3.1**. No code change, no contract touched. §10.3 snapshot unchanged (no agent-guide edit).

## Test plan

- [x] \`make lint\` clean
- [x] \`make docs-build\` strict
- [x] \`make release-check\` builds \`jellycell-1.3.1\` wheel + sdist
- [x] \`tests/unit/test_prompt_snapshot.py\` still passes (bytes unchanged)
- [ ] Post-merge: tag \`v1.3.1\` → PyPI, then loop back to blaise-website with a tiny follow-up prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)