### PR TITLE
fix(run): jc.setup cells are never cached (1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,62 @@ on top if it turns out to be necessary.
   The tag is opt-in and additive; untagged notebooks are byte-for-
   byte identical to the 1.3.1 tearsheet output.
 
+## [1.3.2] — 2026-04-19
+
+Bug-fix patch — `jc.setup` cells now actually behave the way the docs
+(agent guide, `docs/file-format.md`, spec §7) promised: **uncached,
+run first**. Thanks to the blaise-website agent for the tight repro
+(issue [#10](https://github.com/random-walks/jellycell/issues/10)).
+
+### Fixed — `jc.setup` cells are no longer cached
+
+Before 1.3.2, the runner treated setup cells like any other code
+cell: it computed a cache key, and on a cache hit it skipped
+execution entirely. But every `jellycell run` spawns a **fresh
+kernel** — so a cached setup cell's side effects (imports, module
+aliases, global constants) never landed in the kernel namespace.
+Downstream cache-miss cells that referenced those imports then
+failed at runtime with `NameError`.
+
+Minimal reproducer (fails on 1.3.1):
+
+```python
+# notebook.py
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+
+# %% tags=["jc.setup"]
+import jellycell.api as jc
+from IPython.display import Image
+
+# %% tags=["jc.figure", "name=fig1"]
+Image("artifacts/figures/foo.png")
+```
+
+Run once (both cells `ok`). Edit the figure cell. Run again: cell 1
+reports `cached` (wrong — docs said uncached), cell 2 fails with
+`NameError: name 'Image' is not defined`.
+
+1.3.2 takes the preferred of the two fixes noted on the issue:
+**skip the cache for `jc.setup` cells unconditionally** (match the
+docs). Setup cells now always execute, carry no cache key in the
+run report (`cache_key=null`), and leave no manifest / index entry.
+
+### Contracts (§10)
+
+- **§10.2 cache key algorithm**: untouched. The hash function in
+  `cache/hashing.py` is unchanged — we only changed *when the
+  runner consults the cache*, not how keys are computed. No
+  `MINOR_VERSION` bump; existing cache entries for non-setup cells
+  remain valid.
+- **§10.1 `--json` schemas**: the `RunReport` shape is unchanged.
+  `CellResult.cache_key` was already `str | None` — setup cells
+  just now reliably fall into the `None` branch.
+- **§10.3 agent guide**: already accurate. The bug was a behavior
+  mismatch, not a doc mismatch.
+
 ## [1.3.1] — 2026-04-19
 
 Docs patch — fixes a self-contradicting pnpm wrapper recipe

--- a/src/jellycell/run/runner.py
+++ b/src/jellycell/run/runner.py
@@ -218,6 +218,20 @@ class Runner:
         cell_name = cell.spec.name
         cell_id = f"{_stem(notebook_rel)}:{ordinal}"
 
+        # `jc.setup` cells are uncached-by-contract (spec §7, agent-guide
+        # cell-tag table). Every `run` spawns a fresh kernel, so if we
+        # cached a setup cell its side effects — imports, globals — would
+        # vanish and later cache-miss cells would fail at runtime.
+        if cell.spec.kind == "setup":
+            return self._execute_uncached(
+                kernel=kernel,
+                project=project,
+                notebook_rel=notebook_rel,
+                cell=cell,
+                cell_id=cell_id,
+                cell_name=cell_name,
+            )
+
         # Merge tag-declared deps + AST-walked jc.deps(...) + resolved jc.load(...).
         # Static analysis catches the cases the runtime declared_deps can't
         # (because ctx.declared_deps is populated after cache_key is computed).
@@ -291,6 +305,47 @@ class Runner:
             cell_name=cell_name,
             status="ok" if execution.status == "ok" else "error",
             cache_key=cache_key,
+            duration_ms=duration_ms,
+            error=error,
+        )
+
+    def _execute_uncached(
+        self,
+        *,
+        kernel: Kernel,
+        project: Project,
+        notebook_rel: str,
+        cell: Cell,
+        cell_id: str,
+        cell_name: str | None,
+    ) -> CellResult:
+        """Run a cell that opts out of caching (``jc.setup``).
+
+        No cache key, no manifest, no index entry — setup cells leave no
+        trace in the store. ``cache_key`` is ``None`` on the returned
+        :class:`CellResult`, which also keeps them out of ``name_to_key``
+        (setup cells are not addressable as deps).
+        """
+        timeout_s = (
+            float(cell.spec.timeout_s)
+            if cell.spec.timeout_s is not None
+            else float(project.config.run.timeout_seconds)
+        )
+        prelude = _setup_prelude(project, notebook_rel, cell_id, cell_name)
+        t0 = time.perf_counter()
+        _ = kernel.execute(prelude)
+        execution = kernel.execute(cell.source, timeout=timeout_s)
+        duration_ms = int((time.perf_counter() - t0) * 1000)
+
+        error: CellError | None = None
+        if execution.status == "error":
+            error = _extract_error(execution)
+
+        return CellResult(
+            cell_id=cell_id,
+            cell_name=cell_name,
+            status="ok" if execution.status == "ok" else "error",
+            cache_key=None,
             duration_ms=duration_ms,
             error=error,
         )

--- a/tests/integration/test_run_setup_uncached.py
+++ b/tests/integration/test_run_setup_uncached.py
@@ -1,0 +1,133 @@
+"""Regression: ``jc.setup`` cells are never cached.
+
+Spec §7 / agent-guide cell-tag table promise setup cells are "not cached;
+runs first". Prior to the fix for
+https://github.com/random-walks/jellycell/issues/10, the runner applied the
+same cache-hit logic to setup cells as everything else — which meant a
+cached setup cell would not execute on re-run, and any imports it declared
+were absent from the fresh kernel. Subsequent cache-miss cells that
+referenced those imports then failed with ``NameError``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jellycell.config import default_config
+from jellycell.paths import Project
+from jellycell.run import Runner
+
+pytestmark = pytest.mark.integration
+
+
+def _bootstrap_project(tmp_path: Path) -> Project:
+    cfg = default_config("runtest")
+    cfg.dump(tmp_path / "jellycell.toml")
+    for d in ("notebooks", "data", "artifacts", "site", "manuscripts"):
+        (tmp_path / d).mkdir(exist_ok=True)
+    return Project(root=tmp_path.resolve(), config=cfg)
+
+
+# Faithful reproducer from issue #10: a setup cell declares an import,
+# a downstream cell uses it. Between runs the downstream cell is edited,
+# so it cache-misses while the (unchanged) setup cell would otherwise
+# cache-hit.
+BEFORE = (
+    "# /// script\n"
+    '# requires-python = ">=3.11"\n'
+    "# dependencies = []\n"
+    "# ///\n"
+    "\n"
+    '# %% tags=["jc.setup"]\n'
+    "import json\n"
+    "\n"
+    "# %%\n"
+    'print(json.dumps({"v": 1}))\n'
+)
+
+AFTER = BEFORE.replace('{"v": 1}', '{"v": 2}')
+
+
+def test_setup_cell_never_reports_cached(tmp_path: Path) -> None:
+    project = _bootstrap_project(tmp_path)
+    nb_path = project.notebooks_dir / "nb.py"
+    nb_path.write_text(BEFORE, encoding="utf-8")
+
+    runner1 = Runner(project)
+    try:
+        report1 = runner1.run(nb_path)
+    finally:
+        runner1.close()
+    assert report1.status == "ok"
+
+    # Second identical run: the step cell will cache-hit, but the setup
+    # cell must still report ``ok`` (re-executed), never ``cached``.
+    runner2 = Runner(project)
+    try:
+        report2 = runner2.run(nb_path)
+    finally:
+        runner2.close()
+    assert report2.status == "ok"
+    setup_result = report2.cell_results[0]
+    assert setup_result.status == "ok", (
+        f"setup cell status was {setup_result.status!r}; docs promise it is never cached"
+    )
+    # Setup cells carry no cache key (they're not indexed, not addressable).
+    assert setup_result.cache_key is None
+
+
+def test_setup_cell_imports_survive_into_downstream_cache_miss(tmp_path: Path) -> None:
+    """The core bug from issue #10: imports from a setup cell must
+    survive into cache-miss cells on re-runs.
+    """
+    project = _bootstrap_project(tmp_path)
+    nb_path = project.notebooks_dir / "nb.py"
+    nb_path.write_text(BEFORE, encoding="utf-8")
+
+    runner1 = Runner(project)
+    try:
+        runner1.run(nb_path)
+    finally:
+        runner1.close()
+
+    # Edit the downstream cell so it cache-misses on re-run. If the setup
+    # cell were (incorrectly) cached, its ``import json`` would be absent
+    # from the fresh kernel and the step cell would fail with NameError.
+    nb_path.write_text(AFTER, encoding="utf-8")
+    runner2 = Runner(project)
+    try:
+        report2 = runner2.run(nb_path)
+    finally:
+        runner2.close()
+
+    assert report2.status == "ok", [
+        (c.cell_id, c.status, c.error) for c in report2.cell_results
+    ]
+    assert [c.status for c in report2.cell_results] == ["ok", "ok"]
+
+
+def test_setup_cell_not_stored_in_manifest_index(tmp_path: Path) -> None:
+    """Setup cells should leave no trace in the cache manifest index —
+    they're not addressable, so they're not indexed either.
+    """
+    project = _bootstrap_project(tmp_path)
+    nb_path = project.notebooks_dir / "nb.py"
+    nb_path.write_text(BEFORE, encoding="utf-8")
+
+    runner = Runner(project)
+    try:
+        runner.run(nb_path)
+    finally:
+        runner.close()
+
+    from jellycell.cache.index import CacheIndex
+
+    with CacheIndex(project.cache_dir / "state.db") as idx:
+        rows = idx.list_by_notebook("notebooks/nb.py")
+
+    # Only the step cell (ordinal 1) should be indexed; the setup cell
+    # (ordinal 0) is never cached, so it's never indexed.
+    assert len(rows) == 1
+    assert rows[0]["cell_id"].endswith(":1")

--- a/tests/integration/test_run_setup_uncached.py
+++ b/tests/integration/test_run_setup_uncached.py
@@ -102,9 +102,7 @@ def test_setup_cell_imports_survive_into_downstream_cache_miss(tmp_path: Path) -
     finally:
         runner2.close()
 
-    assert report2.status == "ok", [
-        (c.cell_id, c.status, c.error) for c in report2.cell_results
-    ]
+    assert report2.status == "ok", [(c.cell_id, c.status, c.error) for c in report2.cell_results]
     assert [c.status for c in report2.cell_results] == ["ok", "ok"]
 
 


### PR DESCRIPTION
## Summary

Fixes [#10](https://github.com/random-walks/jellycell/issues/10).

The runner was caching `jc.setup` cells like any other code cell, so on re-runs they'd hit the cache and skip execution. But every `jellycell run` spawns a fresh kernel — the setup cell's imports + module aliases never landed in the kernel namespace, and any downstream cache-miss cell that referenced them crashed with `NameError`.

[Spec §7](https://github.com/random-walks/jellycell/blob/main/docs/file-format.md#cell-tags) and the [agent-guide cell-tag table](https://jellycell.readthedocs.io/en/latest/agent-guide.html#cell-tags) both say setup cells are **"not cached; runs first."** This PR aligns behavior with docs.

### The fix

In `_run_one_cell`, check `cell.spec.kind == "setup"` early and route to a new `_execute_uncached` helper that:

- runs the cell against a fresh prelude every time
- never computes a cache key or stores a manifest
- returns `CellResult(cache_key=None, status=…)` so the setup cell also stays out of `name_to_key` (and therefore isn't addressable as a dep, which matches "no deps" in the docs)

Minimal reproducer from the issue (fails on 1.3.1, passes on this branch):

```python
# %% tags=["jc.setup"]
import jellycell.api as jc
from IPython.display import Image

# %% tags=["jc.figure", "name=fig1"]
Image("artifacts/figures/foo.png")
```

Run once → both cells `ok`. Edit cell 2. Run again → **before**: cell 1 `cached`, cell 2 fails with `NameError: name 'Image' is not defined`. **After**: cell 1 `ok`, cell 2 `ok`.

### Regression test

`tests/integration/test_run_setup_uncached.py` covers three axes:
- setup cells never report `cached` on re-runs (status = `ok`, `cache_key is None`)
- imports from a setup cell survive into a downstream cache-miss cell (**catches the original failure mode** — executes the full repro and would have died with `NameError` before the fix)
- setup cells don't appear in the manifest index

The middle test is the one that would catch a regression against the exact bug reported in #10.

## Invariant touched? §10.2 — no

- **§10.1 `--json` schemas**: unchanged. `CellResult.cache_key` was already `str | None`; setup cells just now reliably land in the `None` branch. No `schema_version` bump.
- **§10.2 cache key algorithm**: `cache/hashing.py` is untouched. The hash function's inputs and composition are unchanged — we only changed *when the runner consults the cache*. **`MINOR_VERSION` stays at 1**, existing cache entries for non-setup cells remain valid.
- **§10.3 agent guide**: already accurate. This was a code/docs mismatch where code was wrong.

Version bump: **patch** (1.3.1 → 1.3.2).

## Test plan

- [x] New regression test passes
- [x] `test_run_cached.py`, `test_run_invalidation.py`, `test_run_basic.py` still pass
- [x] `tests/unit/test_hashing.py` snapshot still passes (confirming no algorithm change)
- [x] Full suite: `383 passed`
- [x] `ruff check` clean, `mypy` clean
- [x] End-to-end reproducer from #10 works: run → edit → re-run without NameError
- [ ] Reviewer confirms: the `_execute_uncached` helper is the minimal path; no adjacent code got reshaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)