### PR TITLE
feat(api): jc.figure accepts path-only invocation (1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,15 +54,15 @@ on top if it turns out to be necessary.
 
 ## [1.3.2] — 2026-04-19
 
-Bug-fix patch — `jc.setup` cells now actually behave the way the docs
-(agent guide, `docs/file-format.md`, spec §7) promised: **uncached,
-run first**. Thanks to the blaise-website agent for the tight repro
-(issue [#10](https://github.com/random-walks/jellycell/issues/10)).
+Two independent patches landing in the same release slot — both
+came out of blaise-website dogfood. Thanks to the agent for the
+tight repros.
 
 ### Fixed — `jc.setup` cells are no longer cached
 
-Before 1.3.2, the runner treated setup cells like any other code
-cell: it computed a cache key, and on a cache hit it skipped
+Closes [#10](https://github.com/random-walks/jellycell/issues/10).
+Before this release, the runner treated setup cells like any other
+code cell: it computed a cache key, and on a cache hit it skipped
 execution entirely. But every `jellycell run` spawns a **fresh
 kernel** — so a cached setup cell's side effects (imports, module
 aliases, global constants) never landed in the kernel namespace.
@@ -95,18 +95,59 @@ reports `cached` (wrong — docs said uncached), cell 2 fails with
 docs). Setup cells now always execute, carry no cache key in the
 run report (`cache_key=null`), and leave no manifest / index entry.
 
+### Added — `jc.figure(path)` accepts path-only invocation
+
+Closes [#11](https://github.com/random-walks/jellycell/issues/11).
+Verbatim-mirror analyses with pre-rendered images on disk no longer
+need an `IPython.display.Image` workaround inside a `jc.figure`-tagged
+cell. `jc.figure` now has two modes:
+
+- **Render** (unchanged) — `fig=` given, or omitted with `plt.gcf()`
+  available: save the figure to `path`, honoring `[artifacts] layout`
+  when `path` is `None`.
+- **Path-only** (new) — `fig` omitted *and* `path` points to an existing
+  image file: skip the matplotlib re-encode. The file is registered
+  as an artifact (with caption / notes / tags flowing to the manifest)
+  and inlined via IPython `display(Image(...))` so the cell renders
+  in HTML/ipynb output.
+
+Reduces this boilerplate…
+
+```python
+# %% tags=["jc.figure", "name=fig1"]
+from IPython.display import Image
+Image("artifacts/figures/figure-1.png")
+# — inlines fine but loses caption/notes/tags for the manifest.
+```
+
+…to:
+
+```python
+# %% tags=["jc.figure", "name=fig1"]
+jc.figure(
+    "artifacts/figures/figure-1.png",
+    caption="System-wide ADA coverage",
+)
+```
+
+Fully backwards-compatible: existing call sites with explicit `fig=`
+keep their current behavior. Falling through to the render path
+when the file doesn't exist yet means the old "create on first run"
+pattern also still works.
+
 ### Contracts (§10)
 
-- **§10.2 cache key algorithm**: untouched. The hash function in
-  `cache/hashing.py` is unchanged — we only changed *when the
-  runner consults the cache*, not how keys are computed. No
-  `MINOR_VERSION` bump; existing cache entries for non-setup cells
-  remain valid.
-- **§10.1 `--json` schemas**: the `RunReport` shape is unchanged.
-  `CellResult.cache_key` was already `str | None` — setup cells
-  just now reliably fall into the `None` branch.
-- **§10.3 agent guide**: already accurate. The bug was a behavior
-  mismatch, not a doc mismatch.
+- **§10.2 cache key algorithm**: untouched. The setup-cells fix
+  changed *when the runner consults the cache*, not how keys are
+  computed; no `MINOR_VERSION` bump, existing cache entries for
+  non-setup cells remain valid.
+- **§10.1 `--json` schemas**: `RunReport` shape unchanged.
+  `CellResult.cache_key` was already `str | None`; setup cells now
+  reliably fall into the `None` branch.
+- **§10.3 agent guide**: already accurate. The setup-cells behavior
+  matches what the guide described all along; the new `jc.figure`
+  path-only mode is additive behavior callers opt into by dropping
+  `fig=`.
 
 ## [1.3.1] — 2026-04-19
 

--- a/src/jellycell/api.py
+++ b/src/jellycell/api.py
@@ -58,11 +58,18 @@ def figure(
     tags: list[str] | None = None,
     fig: Any = None,
 ) -> Path:
-    """Save a matplotlib figure. If ``path`` is ``None``, a sensible default is chosen.
+    """Save a matplotlib figure, or register a pre-rendered image at ``path``.
 
-    When no path is given inside a run, the default location respects the
-    project's ``[artifacts] layout`` setting (``flat`` / ``by_notebook`` /
-    ``by_cell``). Explicit paths are always taken verbatim.
+    Two modes:
+
+    - **Render** — ``fig=`` given, or omitted with ``plt.gcf()`` available:
+      the figure is saved to ``path`` (or a sensible default if ``path`` is
+      ``None``, honoring ``[artifacts] layout``).
+    - **Path-only** — ``fig`` omitted and ``path`` points to an existing image
+      file: no matplotlib re-encode. The file is registered as an artifact
+      (metadata attached) and displayed inline via IPython. This is the
+      idiomatic form for verbatim-mirror analyses where figures are
+      pre-rendered on disk.
 
     ``caption`` / ``notes`` / ``tags`` flow into the artifact's
     :class:`ArtifactRecord` and show up in tearsheets alongside the image.
@@ -79,6 +86,20 @@ def figure(
         path_ = str(path)
 
     target = _resolve_out(path_)
+
+    # Path-only invocation: the image already exists on disk — register the
+    # artifact + display inline, skip the matplotlib re-encode. Only triggers
+    # when the caller explicitly passes a path (no auto-default) and didn't
+    # provide a fig; otherwise fall through to the render path.
+    if fig is None and path is not None and target.is_file():
+        # Touch the file so the runner's artifact-diff picks it up. mtime
+        # changes don't affect git (content-addressed), and the touch is a
+        # no-op if the file is outside the project's artifacts_dir.
+        target.touch()
+        _record_artifact_metadata(target, caption=caption, notes=notes, tags=tags)
+        _inline_display_image(target)
+        return target
+
     target.parent.mkdir(parents=True, exist_ok=True)
     if fig is None:
         import matplotlib.pyplot
@@ -87,6 +108,23 @@ def figure(
     fig.savefig(target, bbox_inches="tight")
     _record_artifact_metadata(target, caption=caption, notes=notes, tags=tags)
     return target
+
+
+def _inline_display_image(target: Path) -> None:
+    """Best-effort IPython inline display of an image file.
+
+    No-op outside an IPython-compatible context (plain Python, pytest, etc.);
+    inside a jellycell run the display_data message is captured by the
+    kernel and reattached to the cell on HTML/ipynb export.
+    """
+    try:
+        from IPython.display import Image, display
+    except ImportError:
+        return
+    try:
+        display(Image(filename=str(target)))  # type: ignore[no-untyped-call]
+    except Exception:
+        return
 
 
 def table(

--- a/tests/integration/test_api_in_run.py
+++ b/tests/integration/test_api_in_run.py
@@ -66,3 +66,61 @@ def test_jc_save_registers_artifact_in_manifest(tmp_path: Path) -> None:
     manifest = Manifest.read(manifest_path)
     artifact_paths = [a.path for a in manifest.artifacts]
     assert "artifacts/greeting.json" in artifact_paths
+
+
+# 1x1 transparent PNG — same fixture bytes as the standalone test. Smallest
+# valid payload so we don't need matplotlib to produce a pre-rendered image.
+_TINY_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "000000094944415478da63000100000500010d0a2db40000000049454e44ae4260"
+    "82"
+)
+
+
+NOTEBOOK_WITH_FIGURE_PATH_ONLY = (
+    "# /// script\n"
+    "# dependencies = []\n"
+    "# ///\n"
+    "\n"
+    '# %% tags=["jc.figure", "name=prerendered"]\n'
+    "import jellycell.api as jc\n"
+    "jc.figure(\n"
+    "    'artifacts/figures/prerendered.png',\n"
+    "    caption='Upstream case-study figure',\n"
+    "    tags=['verbatim'],\n"
+    ")\n"
+)
+
+
+def test_jc_figure_path_only_registers_existing_image(tmp_path: Path) -> None:
+    """Pre-rendered image on disk → artifact in manifest with metadata, no re-encode."""
+    project = _bootstrap_project(tmp_path)
+    figures_dir = project.artifacts_dir / "figures"
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    png_path = figures_dir / "prerendered.png"
+    png_path.write_bytes(_TINY_PNG)
+    before = png_path.read_bytes()
+
+    nb_path = project.notebooks_dir / "nb.py"
+    nb_path.write_text(NOTEBOOK_WITH_FIGURE_PATH_ONLY, encoding="utf-8")
+
+    runner = Runner(project)
+    try:
+        report = runner.run(nb_path)
+    finally:
+        runner.close()
+
+    assert report.status == "ok", report
+    cache_key = report.cell_results[0].cache_key
+    assert cache_key is not None
+    manifest = Manifest.read(project.cache_dir / "manifests" / f"{cache_key}.json")
+
+    artifact_paths = [a.path for a in manifest.artifacts]
+    assert "artifacts/figures/prerendered.png" in artifact_paths
+    art = next(a for a in manifest.artifacts if a.path == "artifacts/figures/prerendered.png")
+    assert art.caption == "Upstream case-study figure"
+    assert art.tags == ["verbatim"]
+
+    # The whole point of path-only mode: file contents are untouched (no
+    # matplotlib re-encode, no loss of pixel fidelity from the upstream source).
+    assert png_path.read_bytes() == before

--- a/tests/unit/test_api_standalone.py
+++ b/tests/unit/test_api_standalone.py
@@ -77,3 +77,68 @@ class TestCacheDecorator:
             return x + 1
 
         assert f(1) == 2
+
+
+class TestFigurePathOnly:
+    """``jc.figure(path)`` with a pre-existing image file, no fig="""
+
+    def _write_png(self, target: Path) -> None:
+        # 1x1 transparent PNG — smallest valid payload, avoids a matplotlib dep.
+        payload = bytes.fromhex(
+            "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+            "89000000094944415478da63000100000500010d0a2db40000000049454e44ae"
+            "426082"
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+
+    def test_returns_path_without_re_encoding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "artifacts" / "fig.png"
+        self._write_png(src)
+        before = src.read_bytes()
+
+        out = jc.figure("artifacts/fig.png")
+
+        assert out == src.resolve()
+        # Path-only mode MUST NOT re-encode the image. Content unchanged.
+        assert out.read_bytes() == before
+
+    def test_passes_without_matplotlib_import(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Path-only mode must not pull in matplotlib (cheaper import graph).
+
+        Simulates an environment where matplotlib isn't installed: a call
+        that would have needed ``plt.gcf()`` still works if the path exists.
+        """
+        import sys
+
+        # Sabotage matplotlib imports — if figure() reaches the render path,
+        # the test fails with ImportError.
+        monkeypatch.setitem(sys.modules, "matplotlib", None)
+        monkeypatch.setitem(sys.modules, "matplotlib.pyplot", None)
+
+        monkeypatch.chdir(tmp_path)
+        src = tmp_path / "fig.png"
+        self._write_png(src)
+
+        out = jc.figure("fig.png")
+        assert out.exists()
+
+    def test_no_file_falls_back_to_matplotlib(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ``path`` doesn't point to an existing file, old behavior wins."""
+        monkeypatch.chdir(tmp_path)
+        # No file at "nope.png" — should try to savefig via plt.gcf(). We
+        # assert the ImportError surfaces (no matplotlib here) to confirm
+        # we took the render branch, not the path-only branch.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "matplotlib", None)
+        monkeypatch.setitem(sys.modules, "matplotlib.pyplot", None)
+        with pytest.raises((ImportError, AttributeError)):
+            jc.figure("nope.png")


### PR DESCRIPTION
## Summary

Closes #11.

Makes `fig=` optional on `jellycell.api.figure`. When absent AND
`path` points to an existing image file on disk, `jc.figure`:

1. Registers the artifact in the manifest with any `caption` /
   `notes` / `tags` the caller provides.
2. Inlines the image via IPython `display(Image(...))` so the cell
   renders in HTML / ipynb export.
3. **Skips the matplotlib re-encode** — fidelity of the upstream
   pixels is preserved.

Reduces this verbatim-mirror boilerplate…

```python
# %% tags=["jc.figure", "name=fig1"]
from IPython.display import Image
Image("artifacts/figures/figure-1.png")
# works, but loses caption/notes/tags for the manifest.
```

…to what the docs already hint is the idiomatic pattern:

```python
# %% tags=["jc.figure", "name=fig1"]
jc.figure(
    "artifacts/figures/figure-1.png",
    caption="System-wide ADA coverage",
)
```

## Backwards compatibility

Fully preserved.

- `jc.figure(path, fig=some_fig, ...)` — unchanged.
- `jc.figure(fig=some_fig)` — unchanged (path defaults via `[artifacts] layout`).
- `jc.figure(path)` where `path` **doesn't exist yet** — falls through
  to the render path (`plt.gcf()`), matching the existing "create on
  first run" behavior. Only when the file already exists does the new
  path-only mode kick in.

## Versioning

Patch (1.3.1 → **1.3.2**). The change is ergonomic — it makes an
existing arg optional and adds a new behavior branch gated on file
existence. No public surface is renamed or removed. No §10 contract
touched (no cache-key change, no `--json` schema change, no agent
guide edit). Happy to re-label as minor if you'd rather frame a new
API mode as additive — flag it in review.

## Implementation detail: why `target.touch()`?

The runner discovers artifacts by diffing `(mtime, size)` snapshots
of `artifacts_dir` before/after a cell runs. Pre-existing files
wouldn't show up in the diff, so the call to `target.touch()` inside
path-only mode updates the mtime to force inclusion. Notes:

- `touch()` doesn't modify content → git ignores mtime, so the file
  stays clean in `git status`.
- When the file lives outside `artifacts_dir` (unusual for the
  verbatim-mirror case), the diff wouldn't pick it up anyway — that
  matches the existing artifact-tracking envelope.

## Test plan

- [x] `uv run pytest` — 384 passed, 2 warnings
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run python -m sphinx -W -b html docs docs/_build/html` — clean

New tests:

- `tests/unit/test_api_standalone.py::TestFigurePathOnly` (3 cases)
  covers path-only success, no-matplotlib fallback avoidance, and
  proper fallthrough when the file doesn't exist.
- `tests/integration/test_api_in_run.py::test_jc_figure_path_only_registers_existing_image`
  runs a real kernel on a notebook that uses path-only `jc.figure`
  with caption+tags and asserts the manifest picks up the artifact
  with metadata, without re-encoding the PNG bytes.

## Coordination

This is PR 1 of 4 in a ergonomics batch covering issues #11, #12,
#13+#14, #15. Each PR is independent in code; only `CHANGELOG.md`
and `_version.py` will conflict between them. Version bumps assume
this one lands first (1.3.2); others will rebase on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)