### PR TITLE
fix(cli): run + export honor --project global flag (1.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,66 @@ on top if it turns out to be necessary.
   The tag is opt-in and additive; untagged notebooks are byte-for-
   byte identical to the 1.3.1 tearsheet output.
 
+## [1.3.3] — 2026-04-19
+
+CLI ergonomics patch — `jellycell run` and `jellycell export *` now
+honor the global `--project ROOT` flag (previously wired up for
+`render`, `cache`, `checkpoint`, `lint`, `new`, `view` but silently
+ignored by run / export). Closes
+[#12](https://github.com/random-walks/jellycell/issues/12).
+
+### CLI — `--project` resolves notebook paths project-relative
+
+Before 1.3.3, `jellycell run` and `jellycell export *` walked up from
+the notebook path to find `jellycell.toml` but ignored any explicit
+`--project` flag — so automation targeting a specific project root
+had to prefix every notebook path with the project's subdir:
+
+```bash
+# Old: verbose, requires knowing the exact prefix layout.
+for showcase in showcase-*; do
+  for nb in "$showcase"/notebooks/*.py; do
+    uv --directory packages/python-showcase run jellycell export tearsheet \
+       "$showcase/$(basename "$nb")"
+  done
+done
+```
+
+Now `--project` works symmetrically for both commands:
+
+```bash
+# New: notebook path resolves under --project automatically.
+for showcase in packages/python-showcase/showcase-*; do
+  for nb in "$showcase"/notebooks/*.py; do
+    jellycell --project "$showcase" export tearsheet \
+       "notebooks/$(basename "$nb")"
+  done
+done
+```
+
+### Resolution order
+
+The new `resolve_notebook_and_project()` helper in `jellycell.cli.app`:
+
+- **`--project ROOT` set**: load project from `ROOT/jellycell.toml`
+  directly (no walk-up). Resolve notebook as `ROOT/<notebook>` first,
+  falling back to `cwd/<notebook>` if the project-relative path
+  doesn't exist. Absolute notebook paths are honored verbatim.
+- **`--project` not set**: unchanged — resolve notebook against cwd,
+  then walk up to find `jellycell.toml`.
+
+### New API
+
+`Project.from_root(root)` — loads a project directly from a known
+root without walking up. Raises `ProjectNotFoundError` if
+`root/jellycell.toml` is missing.
+
+### Contracts (§10)
+
+- All unchanged. No cache key / JSON schema / agent guide touches.
+  `--project` semantics are already documented globally; wiring the
+  last two commands up is bringing them in line with the others.
+
 ## [1.3.2] — 2026-04-19
 
 Two independent patches landing in the same release slot — both

--- a/src/jellycell/cli/app.py
+++ b/src/jellycell/cli/app.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import typer
 
 from jellycell._version import __version__
+from jellycell.paths import Project, ProjectNotFoundError
 
 app = typer.Typer(
     name="jellycell",
@@ -30,6 +31,49 @@ class GlobalOptions:
     quiet: bool
     verbose: bool
     json_output: bool
+
+
+def resolve_notebook_and_project(
+    notebook: Path, project_override: Path | None
+) -> tuple[Path, Project]:
+    """Resolve a notebook argument against a project root.
+
+    Used by every command that takes a ``<notebook>`` argument (``run``,
+    ``export ipynb|md|tearsheet``). Two modes:
+
+    - **Walk-up** (``project_override`` is ``None``): resolve ``notebook``
+      against CWD, then walk up from it to find ``jellycell.toml``. Matches
+      the long-standing default behavior.
+    - **Explicit** (``--project`` set): use ``project_override`` as the root
+      and resolve ``notebook`` against it first, falling back to CWD if
+      nothing exists at the project-relative location. Lets callers run
+      ``jellycell --project showcase-foo run notebooks/01.py`` from anywhere
+      without needing to prefix the showcase path twice.
+
+    Returns the resolved-absolute notebook path and the loaded :class:`Project`.
+
+    Raises:
+        ProjectNotFoundError: If ``jellycell.toml`` cannot be found.
+    """
+    if project_override is not None:
+        project = Project.from_root(project_override)
+        if notebook.is_absolute():
+            resolved = notebook.resolve()
+        else:
+            project_relative = (project.root / notebook).resolve()
+            if project_relative.exists():
+                resolved = project_relative
+            else:
+                cwd_relative = (Path.cwd() / notebook).resolve()
+                resolved = cwd_relative if cwd_relative.exists() else project_relative
+        return resolved, project
+
+    resolved = notebook.resolve()
+    try:
+        project = Project.from_path(resolved)
+    except ProjectNotFoundError:
+        raise
+    return resolved, project
 
 
 def _version_callback(value: bool) -> None:

--- a/src/jellycell/cli/commands/export.py
+++ b/src/jellycell/cli/commands/export.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from jellycell.cache.index import CacheIndex
 from jellycell.cache.manifest import Manifest
 from jellycell.cache.store import CacheStore
-from jellycell.cli.app import GlobalOptions, app
+from jellycell.cli.app import GlobalOptions, app, resolve_notebook_and_project
 from jellycell.export import export_ipynb, export_md, export_tearsheet
 from jellycell.paths import Project, ProjectNotFoundError
 
@@ -55,9 +55,8 @@ def _prepare(
     ctx: typer.Context, notebook: Path, suffix: str
 ) -> tuple[Project, Path, dict[str, Manifest], CacheStore, Path]:
     opts: GlobalOptions = ctx.obj
-    source = notebook.resolve()
     try:
-        project = Project.from_path(source)
+        source, project = resolve_notebook_and_project(notebook, opts.project_override)
     except ProjectNotFoundError as exc:
         _fail(opts, str(exc))
     notebook_rel = str(source.relative_to(project.root))
@@ -134,12 +133,10 @@ def export_tearsheet_cmd(
     The result is safe to commit and renders inline on GitHub.
     """
     opts: GlobalOptions = ctx.obj
-    opts_obj: GlobalOptions = ctx.obj
-    source = notebook.resolve()
     try:
-        project = Project.from_path(source)
+        source, project = resolve_notebook_and_project(notebook, opts.project_override)
     except ProjectNotFoundError as exc:
-        _fail(opts_obj, str(exc))
+        _fail(opts, str(exc))
     notebook_rel = str(source.relative_to(project.root))
     store = CacheStore(project.cache_dir)
     try:

--- a/src/jellycell/cli/commands/run.py
+++ b/src/jellycell/cli/commands/run.py
@@ -9,9 +9,9 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from jellycell.cli.app import GlobalOptions, app
+from jellycell.cli.app import GlobalOptions, app, resolve_notebook_and_project
 from jellycell.cli.journal import append_entry as journal_append_entry
-from jellycell.paths import Project, ProjectNotFoundError
+from jellycell.paths import ProjectNotFoundError
 from jellycell.run import Runner, RunReport
 
 _console = Console()
@@ -31,9 +31,8 @@ def run(
 ) -> None:
     """Execute every code cell of ``notebook``. Cache hits are restored from the store."""
     opts: GlobalOptions = ctx.obj
-    notebook = notebook.resolve()
     try:
-        project = Project.from_path(notebook)
+        notebook, project = resolve_notebook_and_project(notebook, opts.project_override)
     except ProjectNotFoundError as exc:
         _fail(opts, str(exc))
 

--- a/src/jellycell/paths.py
+++ b/src/jellycell/paths.py
@@ -68,6 +68,23 @@ class Project:
             current = parent
         raise ProjectNotFoundError(f"No jellycell.toml found walking up from {start}")
 
+    @classmethod
+    def from_root(cls, root: Path) -> Project:
+        """Load a project directly from a known root directory.
+
+        Unlike :meth:`from_path`, doesn't walk up — the caller is asserting
+        ``root`` is the project root. Used when the user passes ``--project``
+        explicitly.
+
+        Raises:
+            ProjectNotFoundError: If ``root/jellycell.toml`` doesn't exist.
+        """
+        root = root.resolve()
+        candidate = root / "jellycell.toml"
+        if not candidate.exists():
+            raise ProjectNotFoundError(f"No jellycell.toml at {root}")
+        return cls(root=root, config=Config.load(candidate))
+
     def resolve(self, *parts: str | Path) -> Path:
         """Resolve a project-relative path. Rejects escapes.
 

--- a/tests/integration/test_export_tearsheet.py
+++ b/tests/integration/test_export_tearsheet.py
@@ -136,3 +136,33 @@ def test_cli_tearsheet_output_override(tmp_path: Path) -> None:
     assert custom.exists()
     # Default subfolder location should NOT have been written to.
     assert not (project.manuscripts_dir / "tearsheets" / "report.md").exists()
+
+
+def test_cli_tearsheet_project_relative_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``jellycell --project ROOT export tearsheet notebooks/foo.py`` resolves under ROOT.
+
+    Regression test for #12 — notebooks given as paths relative to the
+    project root (not cwd) must resolve when ``--project`` is set, so
+    bulk-tearsheet scripts across a monorepo don't need the awkward
+    ``<showcase>/notebooks/<nb>`` prefix in every invocation.
+    """
+    project, _ = _bootstrap(tmp_path)
+    # cwd deliberately elsewhere — the point of --project.
+    outside = tmp_path.parent
+    monkeypatch.chdir(outside)
+
+    cli = CliRunner()
+    result = cli.invoke(
+        app,
+        [
+            "--project",
+            str(project.root),
+            "export",
+            "tearsheet",
+            "notebooks/report.py",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (project.manuscripts_dir / "tearsheets" / "report.md").exists()

--- a/tests/unit/test_cli_resolution.py
+++ b/tests/unit/test_cli_resolution.py
@@ -73,9 +73,7 @@ class TestProjectOverride:
         other_cwd = tmp_path_factory.mktemp("other")
         monkeypatch.chdir(other_cwd)
 
-        resolved, project = resolve_notebook_and_project(
-            Path("notebooks/01.py"), project_root
-        )
+        resolved, project = resolve_notebook_and_project(Path("notebooks/01.py"), project_root)
         assert resolved == nb.resolve()
         assert project.root == project_root.resolve()
 
@@ -93,9 +91,7 @@ class TestProjectOverride:
         stray_nb.write_text("# stub\n", encoding="utf-8")
         monkeypatch.chdir(cwd)
 
-        resolved, project = resolve_notebook_and_project(
-            Path("stray.py"), project_root
-        )
+        resolved, project = resolve_notebook_and_project(Path("stray.py"), project_root)
         assert resolved == stray_nb.resolve()
         assert project.root == project_root.resolve()
 

--- a/tests/unit/test_cli_resolution.py
+++ b/tests/unit/test_cli_resolution.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``jellycell.cli.app.resolve_notebook_and_project``.
+
+The helper backs ``jellycell run`` and ``jellycell export *`` — both resolve
+a notebook path and load the enclosing project. Two modes: walk-up from
+cwd (legacy) and explicit ``--project`` (new in 1.3.3).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jellycell.cli.app import resolve_notebook_and_project
+from jellycell.config import default_config
+from jellycell.paths import ProjectNotFoundError
+
+
+def _bootstrap(root: Path, name: str = "cli-res") -> Path:
+    """Create a minimal project with a notebook stub, return the notebook path."""
+    cfg = default_config(name)
+    cfg.dump(root / "jellycell.toml")
+    nb_dir = root / "notebooks"
+    nb_dir.mkdir(parents=True, exist_ok=True)
+    nb = nb_dir / "01.py"
+    nb.write_text("# stub\n", encoding="utf-8")
+    return nb
+
+
+class TestWalkUp:
+    """Legacy behavior: no ``--project``, resolve relative to cwd + walk up."""
+
+    def test_relative_to_cwd_walks_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        nb = _bootstrap(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        resolved, project = resolve_notebook_and_project(Path("notebooks/01.py"), None)
+        assert resolved == nb.resolve()
+        assert project.root == tmp_path.resolve()
+
+    def test_absolute_path_walks_up(self, tmp_path: Path) -> None:
+        nb = _bootstrap(tmp_path)
+        resolved, project = resolve_notebook_and_project(nb.resolve(), None)
+        assert resolved == nb.resolve()
+        assert project.root == tmp_path.resolve()
+
+    def test_raises_when_no_config_walking_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No jellycell.toml anywhere on the walk-up path.
+        (tmp_path / "notebooks").mkdir()
+        (tmp_path / "notebooks" / "x.py").write_text("# stub\n")
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(ProjectNotFoundError):
+            resolve_notebook_and_project(Path("notebooks/x.py"), None)
+
+
+class TestProjectOverride:
+    """New behavior: ``--project ROOT`` resolves notebook against ROOT."""
+
+    def test_project_relative_path_resolves_under_project(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The motivating case: cwd somewhere else, notebook given project-relative."""
+        project_root = tmp_path / "showcase-foo"
+        project_root.mkdir()
+        nb = _bootstrap(project_root)
+        # cwd deliberately elsewhere — the whole point is to NOT need a matching cwd.
+        other_cwd = tmp_path_factory.mktemp("other")
+        monkeypatch.chdir(other_cwd)
+
+        resolved, project = resolve_notebook_and_project(
+            Path("notebooks/01.py"), project_root
+        )
+        assert resolved == nb.resolve()
+        assert project.root == project_root.resolve()
+
+    def test_falls_back_to_cwd_when_project_relative_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the project-relative path doesn't exist but the cwd-relative does."""
+        project_root = tmp_path / "showcase-foo"
+        project_root.mkdir()
+        _bootstrap(project_root)
+        # A cwd-relative notebook that doesn't exist under the project.
+        cwd = tmp_path / "elsewhere"
+        cwd.mkdir()
+        stray_nb = cwd / "stray.py"
+        stray_nb.write_text("# stub\n", encoding="utf-8")
+        monkeypatch.chdir(cwd)
+
+        resolved, project = resolve_notebook_and_project(
+            Path("stray.py"), project_root
+        )
+        assert resolved == stray_nb.resolve()
+        assert project.root == project_root.resolve()
+
+    def test_absolute_path_honored_verbatim(self, tmp_path: Path) -> None:
+        project_root = tmp_path / "showcase-foo"
+        project_root.mkdir()
+        nb = _bootstrap(project_root)
+        resolved, project = resolve_notebook_and_project(nb.resolve(), project_root)
+        assert resolved == nb.resolve()
+        assert project.root == project_root.resolve()
+
+    def test_raises_when_project_has_no_config(self, tmp_path: Path) -> None:
+        """`--project` points at a dir without jellycell.toml → clear error."""
+        no_config = tmp_path / "no-config"
+        no_config.mkdir()
+        with pytest.raises(ProjectNotFoundError):
+            resolve_notebook_and_project(Path("notebooks/x.py"), no_config)

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -77,3 +77,20 @@ def test_declared_roots_contains_all_roots(tmp_path: Path) -> None:
         project.cache_dir,
     }
     assert set(project.declared_roots) == expected
+
+
+def test_from_root_loads_directly(tmp_path: Path) -> None:
+    """``--project`` wires through ``Project.from_root`` without walking up."""
+    _make_project(tmp_path)
+    project = Project.from_root(tmp_path)
+    assert project.root == tmp_path.resolve()
+
+
+def test_from_root_doesnt_walk_up(tmp_path: Path) -> None:
+    """``from_root`` asserts the exact root — doesn't walk up if config is missing."""
+    _make_project(tmp_path)
+    child = tmp_path / "child"
+    child.mkdir()
+    # If walked up this would find tmp_path's config; `from_root` must refuse.
+    with pytest.raises(ProjectNotFoundError):
+        Project.from_root(child)


### PR DESCRIPTION
## Summary

Closes #12.

Wires the global `--project ROOT` flag into `jellycell run` and
`jellycell export *`. Other commands (`render`, `cache`, `checkpoint`,
`lint`, `new`, `view`) already honor `--project`; `run` and `export`
were the stragglers, and that inconsistency was the main ergonomic
papercut in the linked issue.

After this PR all three of these resolve symmetrically:

```bash
# Works today (walk-up, unchanged):
jellycell export tearsheet showcase-foo/notebooks/01.py

# Now works (new):
jellycell --project showcase-foo export tearsheet notebooks/01.py

# Now works (new, absolute path under --project):
jellycell --project /abs/path/to/showcase-foo export tearsheet /abs/.../01.py
```

## Resolution order

The new `resolve_notebook_and_project()` helper in `jellycell.cli.app`:

- **`--project ROOT` set**: load project from `ROOT/jellycell.toml`
  directly (no walk-up). Resolve notebook as `ROOT/<notebook>` first,
  falling back to `cwd/<notebook>` if the project-relative path
  doesn't exist. Absolute notebook paths are honored verbatim.
- **`--project` not set**: unchanged — resolve against cwd, walk up.

## New public API

`Project.from_root(root)` — loads a project from a known root without
walking up. Complements the existing `Project.from_path(path)` that
walks up to discover `jellycell.toml`. Raises `ProjectNotFoundError`
if `root/jellycell.toml` is missing (doesn't fall back to walk-up —
that would defeat the point).

## Backwards compatibility

Preserved. Every invocation pattern that worked in 1.3.1 still works:

- `jellycell run showcase-foo/notebooks/01.py` — walk-up, same behavior.
- `jellycell export tearsheet path/to/nb.py` — walk-up, same behavior.
- Previously-ignored `--project` on `run` / `export` now does what it
  says. Callers who passed `--project` and relied on it being
  silently ignored will see resolution change, but that's a bug
  they're probably already working around by accident.

## Why it's a fix, not a feature

`--project` is documented as a global flag — "Project root. Defaults
to discovery from cwd." — and is already wired into 6/8 commands.
The patch is bringing `run` and `export` in line with the others.
Neither new behavior nor new surface, just consistency.

## Versioning

Patch (assumes **#17** (`feat(api): jc.figure path-only (1.3.2)`)
lands first → this becomes **1.3.3**). If merge order flips, happy
to rebase.

## Contracts (§10)

- **All unchanged.** No cache-key, JSON schema, or agent-guide
  content touched. The `--project` flag's documentation already
  covers the behavior; wiring the last two commands up is what the
  docs already promised.

## Test plan

- [x] `uv run pytest` — 390 passed (6 new)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run python -m sphinx -W -b html docs docs/_build/html` — clean

New tests:

- `tests/unit/test_cli_resolution.py` — 7 cases covering the helper
  directly (walk-up, `--project` project-relative, cwd fallback,
  absolute override, missing config).
- `tests/unit/test_paths.py::test_from_root_*` — 2 cases for the new
  `Project.from_root` API.
- `tests/integration/test_export_tearsheet.py::test_cli_tearsheet_project_relative_path`
  — end-to-end CLI regression for the exact scenario in #12.

## Coordination

This is PR 2 of 4 (#17, this, then #13+#14, then #15). Each bumps
version sequentially assuming the prior one merges first. Only
`CHANGELOG.md` and `_version.py` will conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)