### PR TITLE
feat(api): jc.table first-run ergonomics — ship pyarrow + auto-cast mixed columns (1.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,68 @@ on top if it turns out to be necessary.
   The tag is opt-in and additive; untagged notebooks are byte-for-
   byte identical to the 1.3.1 tearsheet output.
 
+## [1.3.4] — 2026-04-19
+
+`jc.table` first-run ergonomics patch — pyarrow is now shipped by
+default, and mixed-dtype object columns (common in regression
+output) round-trip instead of crashing pyarrow's parquet writer.
+Closes [#13](https://github.com/random-walks/jellycell/issues/13)
+and [#14](https://github.com/random-walks/jellycell/issues/14).
+
+### Deps — `pyarrow` is a default dependency
+
+Before 1.3.4, calling `jc.table(df)` on a clean install raised
+`ImportError: Unable to find a usable engine; tried using: 'pyarrow',
+'fastparquet'` because pandas needs a parquet engine and pyarrow
+isn't a pandas-core dep. Every user hit this on the first `jc.table`
+cell.
+
+`pyarrow>=15` moved from the `[examples]` optional extra into
+`[project].dependencies`. Rationale:
+
+- pandas 3.x is moving toward pyarrow-backed dtypes by default, so
+  pyarrow is becoming non-optional for most pandas users anyway.
+- The wheel is ~30 MB — small enough that the default-install cost
+  is outweighed by a working first-run.
+- `jc.table` is the canonical tabular primitive; a user running
+  their first notebook shouldn't have to diagnose a pandas error to
+  find out they need a separate package.
+
+Also, as a belt-and-suspenders for environments where pyarrow is
+somehow missing at runtime (forcibly uninstalled, import failure),
+`jc.table` now re-raises any `ImportError` from `to_parquet` with a
+clean message pointing at `pip install pyarrow`.
+
+### API — mixed-dtype columns auto-cast to string
+
+`jc.table` now detects object columns whose inferred dtype is
+``mixed*`` (per `pandas.api.types.infer_dtype`) and casts them to
+string before writing. Pure-string and pure-numeric columns are
+untouched.
+
+Before:
+
+```python
+df = pd.DataFrame({"var": ["x", "y"], "p": ["<.001", 0.84]})
+jc.table(df, name="ols")
+# → ArrowInvalid: Could not convert '<.001' with type str: tried to
+#   convert to double (deep in pyarrow's parquet writer).
+```
+
+After: the `p` column is cast to string before write, round-trips as
+string on `pd.read_parquet`. The information loss is minimal for the
+common case (p-values, categorical labels that may have been typed
+as numbers); callers who need a specific dtype should pre-cast
+explicitly.
+
+### Contracts (§10)
+
+- All unchanged. No cache-key, JSON schema, or agent-guide content
+  touched. The auto-cast is additive behavior that surfaces on an
+  input type that previously crashed, so it doesn't affect
+  round-trips for any DataFrame that worked in 1.3.1. Adding a
+  default dependency is a standard patch-level change.
+
 ## [1.3.3] — 2026-04-19
 
 CLI ergonomics patch — `jellycell run` and `jellycell export *` now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
     "jinja2>=3",
     "platformdirs>=4",
     "tomli-w>=1",
+    # pyarrow: required by jc.table for parquet serialization. Shipped by
+    # default (~30 MB wheel) so users hit a working first-run instead of
+    # an ImportError from pandas. pandas 3.x is also moving toward pyarrow-
+    # backed dtypes by default, so this is increasingly non-optional.
+    "pyarrow>=15",
 ]
 
 [project.optional-dependencies]
@@ -61,7 +66,6 @@ examples = [
     "numpy>=1.26",
     "pandas>=2.0",
     "matplotlib>=3.7",
-    "pyarrow>=15",
 ]
 all = ["jellycell[server]"]
 dev = [

--- a/src/jellycell/api.py
+++ b/src/jellycell/api.py
@@ -139,14 +139,65 @@ def table(
 
     Like :func:`figure`, the default path honors ``[artifacts] layout`` and
     ``caption`` / ``notes`` / ``tags`` flow into the artifact's manifest record.
+
+    Object columns with mixed types (e.g., a p-value column holding both
+    ``"<.001"`` strings and numeric floats) are automatically cast to string
+    before serialization — pyarrow rejects mixed dtypes with a cryptic error
+    deep in the parquet writer, and the information loss of treating
+    everything-as-string is minimal for the common regression-output case.
+    Pure-string and pure-numeric object columns are left untouched.
     """
     ctx = get_context()
     stem = name or (ctx.cell_name if ctx and ctx.cell_name else "table")
     target = _resolve_out(_layout_path(ctx, stem, "parquet"))
     target.parent.mkdir(parents=True, exist_ok=True)
-    df.to_parquet(target)
+    normalized = _normalize_object_columns(df)
+    try:
+        normalized.to_parquet(target)
+    except ImportError as exc:
+        raise ImportError(
+            "jc.table requires pyarrow to serialize DataFrames to parquet. "
+            "Install with: pip install pyarrow"
+        ) from exc
     _record_artifact_metadata(target, caption=caption, notes=notes, tags=tags)
     return target
+
+
+def _normalize_object_columns(df: Any) -> Any:
+    """Auto-cast object columns with mixed dtypes to string.
+
+    pyarrow's parquet writer requires one dtype per column. Pandas stores
+    heterogeneous columns as ``object`` and pyarrow picks a dtype on write —
+    mixed float+str columns (common in regression output, where a p-value
+    cell may be either ``"<.001"`` or ``0.84``) blow up with an
+    ``ArrowInvalid`` deep in the serializer.
+
+    We detect columns where pandas' :func:`~pandas.api.types.infer_dtype`
+    returns a ``mixed*`` code and cast them to string before write. Pure-str
+    object columns and pure-numeric columns are left untouched so their
+    round-trip dtype stays faithful.
+
+    Returns a shallow copy with the normalization applied; the caller's
+    DataFrame is not mutated.
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        return df
+    if not isinstance(df, pd.DataFrame):
+        return df
+    mixed_cols = [
+        col
+        for col in df.columns
+        if df[col].dtype == object
+        and pd.api.types.infer_dtype(df[col], skipna=True).startswith("mixed")
+    ]
+    if not mixed_cols:
+        return df
+    out = df.copy()
+    for col in mixed_cols:
+        out[col] = out[col].astype("string")
+    return out
 
 
 def _record_artifact_metadata(

--- a/tests/unit/test_api_standalone.py
+++ b/tests/unit/test_api_standalone.py
@@ -187,9 +187,7 @@ class TestTableMixedObjectColumns:
         restored = pd.read_parquet(out)
         assert restored["label"].tolist() == ["alpha", "beta", "gamma"]
 
-    def test_float_column_untouched(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_float_column_untouched(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Pure-float columns serialize at native precision — no stringification."""
         pd = pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")

--- a/tests/unit/test_api_standalone.py
+++ b/tests/unit/test_api_standalone.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import pickle
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -142,3 +143,99 @@ class TestFigurePathOnly:
         monkeypatch.setitem(sys.modules, "matplotlib.pyplot", None)
         with pytest.raises((ImportError, AttributeError)):
             jc.figure("nope.png")
+
+
+class TestTableMixedObjectColumns:
+    """``jc.table`` auto-casts object columns with mixed dtypes to string.
+
+    Regression for
+    https://github.com/random-walks/jellycell/issues/14 — pyarrow rejected
+    mixed float+str object columns with a cryptic error deep in the parquet
+    serializer. Auto-casting to string before write sidesteps the issue and
+    preserves information for the common regression-output case (p-values
+    that may be either a numeric like ``0.84`` or a string like ``"<.001"``).
+    """
+
+    def test_mixed_str_float_column_roundtrips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        monkeypatch.chdir(tmp_path)
+
+        df = pd.DataFrame({"var": ["x", "y", "z"], "p": ["<.001", 0.999, 0.84]})
+        out = jc.table(df, name="ols")
+
+        restored = pd.read_parquet(out)
+        assert list(restored.columns) == ["var", "p"]
+        # The mixed column came back as string — values preserved.
+        assert restored["p"].tolist() == ["<.001", "0.999", "0.84"]
+
+    def test_pure_string_column_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pure-str object columns don't trigger the mixed-dtype path."""
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        monkeypatch.chdir(tmp_path)
+
+        df = pd.DataFrame({"label": ["alpha", "beta", "gamma"]})
+        original = df.copy()
+        out = jc.table(df, name="labels")
+        # Caller's DataFrame must not be mutated — normalization returns a copy.
+        assert df.equals(original)
+        restored = pd.read_parquet(out)
+        assert restored["label"].tolist() == ["alpha", "beta", "gamma"]
+
+    def test_float_column_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pure-float columns serialize at native precision — no stringification."""
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        monkeypatch.chdir(tmp_path)
+
+        df = pd.DataFrame({"x": [1.0, 2.5, 3.25]})
+        out = jc.table(df, name="xs")
+        restored = pd.read_parquet(out)
+        # Dtype preserved; values exact.
+        assert restored["x"].dtype.kind == "f"
+        assert restored["x"].tolist() == [1.0, 2.5, 3.25]
+
+    def test_missing_pyarrow_surfaces_clean_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If pyarrow is somehow missing at runtime, the error calls out jellycell.
+
+        Belt-and-suspenders for #13: pyarrow is a default dep now, but users
+        who uninstall it (or hit an import failure) should see a message
+        pointing at the `pip install pyarrow` fix rather than a raw pandas
+        ImportError that doesn't mention jellycell.
+        """
+        pd = pytest.importorskip("pandas")
+        monkeypatch.chdir(tmp_path)
+
+        class _FrameWithoutParquet:
+            """Stand-in for a DataFrame whose to_parquet raises ImportError."""
+
+            def __init__(self, df: Any) -> None:
+                self._df = df
+                self.columns = df.columns
+                self.dtypes = df.dtypes
+
+            def copy(self) -> _FrameWithoutParquet:
+                return _FrameWithoutParquet(self._df.copy())
+
+            def __getitem__(self, k: Any) -> Any:
+                return self._df[k]
+
+            def to_parquet(self, target: Any) -> None:
+                raise ImportError("Unable to find a usable engine")
+
+        # Skip the auto-cast path — pass through a plain DataFrame, but swap
+        # its to_parquet attribute so we exercise the ImportError branch.
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        monkeypatch.setattr(df, "to_parquet", _FrameWithoutParquet(df).to_parquet)
+
+        with pytest.raises(ImportError, match=r"jc\.table requires pyarrow"):
+            jc.table(df, name="x")

--- a/uv.lock
+++ b/uv.lock
@@ -1206,6 +1206,7 @@ dependencies = [
     { name = "nbconvert" },
     { name = "nbformat" },
     { name = "platformdirs" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pygments" },
     { name = "rich" },
@@ -1230,7 +1231,6 @@ dev = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pre-commit" },
-    { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1266,7 +1266,6 @@ examples = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pyarrow" },
 ]
 server = [
     { name = "sse-starlette" },
@@ -1302,8 +1301,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'examples'", specifier = ">=2.0" },
     { name = "platformdirs", specifier = ">=4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3" },
-    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=15" },
-    { name = "pyarrow", marker = "extra == 'examples'", specifier = ">=15" },
+    { name = "pyarrow", specifier = ">=15" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pygments", specifier = ">=2.17" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },


### PR DESCRIPTION
## Summary

Combined PR addressing #13 and #14 — both hit every user running
their first `jc.table` cell on a clean install, both touch
`jellycell.api.table`, so bundling them for one review pass.

### #13 — `pyarrow` is now a default dep

Before 1.3.4, `jc.table(df)` on a clean install raised:

```
ImportError: Unable to find a usable engine; tried using:
'pyarrow', 'fastparquet'. A suitable version of pyarrow or
fastparquet is required for parquet support.
```

This is the first thing every new jellycell user saw on their
first `jc.table` call — pyarrow isn't a pandas-core dep, so pandas
needs a separate install to write parquet.

Moving `pyarrow>=15` from the `[examples]` optional extra into
`[project].dependencies`. Rationale:

- pandas 3.x is moving toward pyarrow-backed dtypes by default, so
  pyarrow is becoming non-optional for most pandas-heavy workflows.
- The wheel is ~30 MB — small price for a working first-run.
- `jc.table` is the canonical tabular primitive; users shouldn't
  have to diagnose a pandas error to find out they need a separate
  package.

**This is the decision point you may want to weigh in on.** The
issue flagged three options:

- (a) **Ship pyarrow default** — what this PR does.
- (b) Detect missing engine + cleaner error.
- (c) Fall back to CSV.

If you'd rather not take the +30 MB default install hit, I'll strip
the dep change and ship just (b) (the cleaner-error path is also
here — see the belt-and-suspenders note below — it just
becomes the primary fix instead of the fallback).

Belt-and-suspenders: `jc.table` also catches `ImportError` from
`to_parquet` and re-raises with a jellycell-branded message
pointing at `pip install pyarrow`. So if a user somehow ends up
without pyarrow (e.g., forcibly uninstalled), they see:

```
ImportError: jc.table requires pyarrow to serialize DataFrames to
parquet. Install with: pip install pyarrow
```

…instead of the opaque pandas error.

### #14 — mixed-dtype object columns auto-cast to string

```python
df = pd.DataFrame({"var": ["x", "y", "z"], "p": ["<.001", 0.999, 0.84]})
jc.table(df, name="ols")
# Before: ArrowInvalid deep in pyarrow's parquet writer.
# After:  'p' column cast to string, serializes cleanly;
#         round-trips as ["<.001", "0.999", "0.84"].
```

New helper `_normalize_object_columns(df)` walks the DataFrame,
finds object columns whose `pandas.api.types.infer_dtype(col,
skipna=True)` returns a `mixed*` code (e.g., `mixed`,
`mixed-integer`, `mixed-integer-float`), and casts them to
`pd.StringDtype()` on a shallow copy. Pure-str and pure-numeric
columns are untouched so their round-trip dtypes stay faithful,
and the caller's DataFrame is never mutated.

Chose option (a) from the issue (auto-cast) over option (b)
(cleaner error with column name) because:

- It's least-surprise for the common case — p-value columns with
  a mix of strings like `"<.001"` and floats like `0.84` are a
  natural shape, not a user mistake.
- String serialization loses no information — p-values display
  fine as strings and regression output tables rarely consume the
  numeric type downstream.
- Users who need a specific dtype can pre-cast explicitly.

## Backwards compatibility

Preserved.

- DataFrames that worked in 1.3.1 still work identically — pure-str
  and pure-numeric columns skip the normalization path.
- Default-dep change is strictly additive (no removed extras; the
  `[examples]` extra just no longer includes pyarrow since it's now
  in the core deps).
- Error-on-missing-pyarrow is a clearer message for the same error
  condition; never surfaces on a working install.

## Versioning

Patch (assumes #17 and #18 land first → this becomes **1.3.4**).
Happy to rebase if merge order changes.

## Contracts (§10)

- All unchanged. No cache-key / JSON schema / agent-guide touches.
  Default-dep additions are explicitly patch-level per
  `docs/development/releasing.md` ("dependency bumps with no
  observable behavior change"). The auto-cast behavior is additive
  on an input shape that previously crashed, so no regression
  surface for working DataFrames.

## Test plan

- [x] `uv run pytest` — 384 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run python -m sphinx -W -b html docs docs/_build/html` — clean

New tests in `tests/unit/test_api_standalone.py::TestTableMixedObjectColumns`:

- `test_mixed_str_float_column_roundtrips` — the motivating case
  from #14 writes + reads back, values preserved as string.
- `test_pure_string_column_untouched` — pure-str columns serialize
  through unchanged (and we explicitly assert the caller's df is
  not mutated).
- `test_float_column_untouched` — pure-float columns keep native
  precision.
- `test_missing_pyarrow_surfaces_clean_error` — verifies the
  belt-and-suspenders message when the parquet engine is missing.

## Coordination

PR 3 of 4 (#17 jc.figure path-only, #18 CLI --project, this,
then #15 tearsheet filtering). Only `CHANGELOG.md` + `_version.py`
+ `pyproject.toml`/`uv.lock` conflict with the others; I'll rebase
on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)