### PR TITLE
feat(export): tearsheet artifact filtering via tearsheet tag (1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [Unreleased]
 
+## [1.3.5] — 2026-04-19
+
+Tearsheet artifact filtering — scope a noisy notebook's tearsheet to
+the artifacts that actually belong there, via a declarative
+``tearsheet`` tag. Closes
+[#15](https://github.com/random-walks/jellycell/issues/15).
+
+### Export — ``tearsheet`` tag opt-in
+
+Notebooks with many intermediate debug artifacts previously produced
+noisy tearsheets; cleaning up required either deleting intermediate
+files or hand-editing the generated markdown (both lost on
+regeneration). Now you can mark the polished subset with a
+``tearsheet`` tag at either granularity:
+
+```python
+# Cell-level — every artifact from this cell is included.
+# %% tags=["jc.figure", "name=fig1", "tearsheet"]
+jc.figure("artifacts/headline.png", caption="Main result")
+
+# Or artifact-level — fine-grained (a cell can produce many artifacts,
+# only some tearsheet-worthy):
+jc.save(debug_dict, "artifacts/debug.json")                  # excluded
+jc.save(headline, "artifacts/headline.json",
+        tags=["tearsheet"])                                  # included
+```
+
+Filtering is **auto-enabled** when any artifact in the run carries
+the tag (cell- or artifact-level). A notebook with no tagging
+behaves exactly as before — every renderable artifact is inlined.
+
+### Why tag-based over CLI flag
+
+We considered a ``--include-artifacts`` glob flag for one-off
+exports. Tag-based is declarative and persistent: the notebook
+self-documents which artifacts are tearsheet-worthy, and every
+subsequent ``jellycell export tearsheet`` produces the same output
+without re-typing globs. A follow-up minor can layer a CLI override
+on top if it turns out to be necessary.
+
+### Contracts (§10)
+
+- All unchanged. No cache-key / JSON schema / agent-guide touches.
+  The tag is opt-in and additive; untagged notebooks are byte-for-
+  byte identical to the 1.3.1 tearsheet output.
+
 ## [1.3.1] — 2026-04-19
 
 Docs patch — fixes a self-contradicting pnpm wrapper recipe

--- a/src/jellycell/_version.py
+++ b/src/jellycell/_version.py
@@ -16,7 +16,7 @@ See CLAUDE.md and spec §10 for the full contract.
 
 from __future__ import annotations
 
-__version__ = "1.3.1"
+__version__ = "1.3.5"
 
 MINOR_VERSION: int = 1
 """Spec §10.2 cache-key counter. Bump on any cache/hashing behavior change.

--- a/src/jellycell/export/tearsheet.py
+++ b/src/jellycell/export/tearsheet.py
@@ -18,6 +18,27 @@ Inclusion rules:
 - Everything else (plain ``step`` cells, parquet artifacts, stream output,
   display-data blobs) is skipped.
 
+## Artifact filtering — ``tearsheet`` tag (opt-in)
+
+For notebooks with many intermediate debug artifacts, mark the subset
+that belongs on the polished tearsheet with the ``tearsheet`` tag,
+either on the cell or on the artifact:
+
+    # Cell-level tag — all artifacts from this cell are included.
+    # %% tags=["jc.figure", "name=fig1", "tearsheet"]
+    jc.figure("artifacts/headline.png", caption="Main result")
+
+    # Or artifact-level — fine-grained (a cell can produce multiple
+    # artifacts, only some tearsheet-worthy):
+    jc.save(debug_dict, "artifacts/debug.json")                # excluded
+    jc.save(headline, "artifacts/headline.json",
+            tags=["tearsheet"])                                # included
+
+Filtering is auto-enabled when **any** artifact in the run carries
+the ``tearsheet`` tag (cell- or artifact-level). A notebook with no
+tagging behaves exactly as before — every renderable artifact is
+inlined — so the feature is strictly additive.
+
 Default output is ``manuscripts/tearsheets/<stem>.md``. That subfolder
 convention keeps auto-generated files out of the hand-authored work that
 lives at the root of ``manuscripts/`` — paper drafts, decision memos,
@@ -37,6 +58,7 @@ from jellycell.format import parse as format_parse
 from jellycell.format.cells import Cell, Notebook
 
 _IMAGE_EXTS = frozenset({"png", "svg", "jpg", "jpeg", "gif", "webp"})
+_TEARSHEET_TAG = "tearsheet"
 
 
 def export_tearsheet(
@@ -58,6 +80,8 @@ def export_tearsheet(
     stem = notebook_path.stem
     notebook_rel = notebook_path.resolve().relative_to(project_root.resolve())
     out_dir = output_path.parent.resolve()
+    tearsheet_cell_ids = _cells_tagged_tearsheet(nb, stem)
+    tearsheet_only = _any_tearsheet_tag(manifests_by_cell, tearsheet_cell_ids)
 
     lines: list[str] = []
     title, title_cell_ordinal = _extract_title(nb, fallback=stem)
@@ -76,6 +100,8 @@ def export_tearsheet(
             out_dir=out_dir,
             project_root=project_root,
             skip_title_ordinal=title_cell_ordinal,
+            tearsheet_only=tearsheet_only,
+            tearsheet_cell_ids=tearsheet_cell_ids,
         )
         if cell_lines:
             lines.extend(cell_lines)
@@ -93,6 +119,56 @@ def export_tearsheet(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
     return output_path
+
+
+def _cells_tagged_tearsheet(nb: Notebook, stem: str) -> set[str]:
+    """Return cell_ids whose raw metadata tags include ``tearsheet``.
+
+    Tags at the cell level mark every artifact the cell produces as
+    tearsheet-worthy. Complements artifact-level ``tags=["tearsheet"]``
+    on ``jc.*`` calls, which is finer-grained.
+    """
+    out: set[str] = set()
+    for ordinal, cell in enumerate(nb.cells):
+        raw_tags = cell.metadata.get("tags", [])
+        if isinstance(raw_tags, list) and _TEARSHEET_TAG in raw_tags:
+            out.add(f"{stem}:{ordinal}")
+    return out
+
+
+def _any_tearsheet_tag(
+    manifests_by_cell: dict[str, Manifest], tearsheet_cell_ids: set[str]
+) -> bool:
+    """Determine whether tag-based filtering should kick in for this notebook.
+
+    Returns ``True`` when at least one cell or artifact carries the
+    ``tearsheet`` tag — in which case the exporter includes only tagged
+    artifacts. When nothing is tagged, we keep the legacy include-everything
+    behavior (strictly additive upgrade).
+    """
+    if tearsheet_cell_ids:
+        return True
+    for manifest in manifests_by_cell.values():
+        for art in manifest.artifacts:
+            if _TEARSHEET_TAG in art.tags:
+                return True
+    return False
+
+
+def _artifact_passes_filter(
+    art: Any, cell_id: str, tearsheet_only: bool, tearsheet_cell_ids: set[str]
+) -> bool:
+    """Return whether ``art`` should be inlined given the current filter.
+
+    When ``tearsheet_only`` is off, everything passes — legacy behavior.
+    When on, the artifact must either carry the ``tearsheet`` tag itself
+    or belong to a cell whose metadata tags include it.
+    """
+    if not tearsheet_only:
+        return True
+    if _TEARSHEET_TAG in art.tags:
+        return True
+    return cell_id in tearsheet_cell_ids
 
 
 def _extract_title(nb: Notebook, *, fallback: str) -> tuple[str, int | None]:
@@ -147,6 +223,8 @@ def _render_cell(
     out_dir: Path,
     project_root: Path,
     skip_title_ordinal: int | None,
+    tearsheet_only: bool,
+    tearsheet_cell_ids: set[str],
 ) -> list[str]:
     """Render one cell into tearsheet lines. Empty list = skip."""
     if cell.cell_type == "markdown":
@@ -154,15 +232,35 @@ def _render_cell(
     if cell.cell_type != "code":
         return []
 
-    manifest = manifests_by_cell.get(f"{stem}:{ordinal}")
+    cell_id = f"{stem}:{ordinal}"
+    manifest = manifests_by_cell.get(cell_id)
     lines: list[str] = []
 
     if cell.spec.kind == "setup":
         lines.extend(_render_setup_cell(cell))
 
     if manifest is not None:
-        lines.extend(_render_image_artifacts(cell, manifest, out_dir, project_root))
-        lines.extend(_render_json_artifacts(cell, manifest, project_root))
+        lines.extend(
+            _render_image_artifacts(
+                cell,
+                manifest,
+                out_dir,
+                project_root,
+                cell_id=cell_id,
+                tearsheet_only=tearsheet_only,
+                tearsheet_cell_ids=tearsheet_cell_ids,
+            )
+        )
+        lines.extend(
+            _render_json_artifacts(
+                cell,
+                manifest,
+                project_root,
+                cell_id=cell_id,
+                tearsheet_only=tearsheet_only,
+                tearsheet_cell_ids=tearsheet_cell_ids,
+            )
+        )
 
     return lines
 
@@ -196,7 +294,14 @@ def _render_setup_cell(cell: Cell) -> list[str]:
 
 
 def _render_image_artifacts(
-    cell: Cell, manifest: Manifest, out_dir: Path, project_root: Path
+    cell: Cell,
+    manifest: Manifest,
+    out_dir: Path,
+    project_root: Path,
+    *,
+    cell_id: str,
+    tearsheet_only: bool,
+    tearsheet_cell_ids: set[str],
 ) -> list[str]:
     """Inline each image artifact with optional caption/notes/tags trailers.
 
@@ -214,6 +319,8 @@ def _render_image_artifacts(
     """
     lines: list[str] = []
     for art in manifest.artifacts:
+        if not _artifact_passes_filter(art, cell_id, tearsheet_only, tearsheet_cell_ids):
+            continue
         ext = art.path.rsplit(".", 1)[-1].lower() if "." in art.path else ""
         if ext not in _IMAGE_EXTS:
             continue
@@ -231,7 +338,15 @@ def _render_image_artifacts(
     return lines
 
 
-def _render_json_artifacts(cell: Cell, manifest: Manifest, project_root: Path) -> list[str]:
+def _render_json_artifacts(
+    cell: Cell,
+    manifest: Manifest,
+    project_root: Path,
+    *,
+    cell_id: str,
+    tearsheet_only: bool,
+    tearsheet_cell_ids: set[str],
+) -> list[str]:
     """Flatten JSON artifacts into a two-column table.
 
     Label precedence: explicit ``caption`` from the ``jc.save(..., caption=...)``
@@ -242,6 +357,8 @@ def _render_json_artifacts(cell: Cell, manifest: Manifest, project_root: Path) -
     _ = cell
     lines: list[str] = []
     for art in manifest.artifacts:
+        if not _artifact_passes_filter(art, cell_id, tearsheet_only, tearsheet_cell_ids):
+            continue
         if not art.path.endswith(".json"):
             continue
         abs_path = project_root / art.path

--- a/tests/unit/test_tearsheet.py
+++ b/tests/unit/test_tearsheet.py
@@ -387,4 +387,166 @@ class TestHeaderAndFooter:
         )
         text = out.read_text(encoding="utf-8")
         assert "Auto-generated" in text
+
+
+class TestTearsheetTagFiltering:
+    """Artifact filtering via the ``tearsheet`` tag (closes #15).
+
+    When no cell/artifact carries the tag, behavior is unchanged (everything
+    renderable inlines). When the tag appears anywhere in the notebook's
+    artifacts or cell metadata, the exporter switches to opt-in mode and
+    includes only artifacts tagged tearsheet (or produced by a tagged cell).
+    """
+
+    _NOTEBOOK_TWO_FIGS = (
+        "# /// script\n# dependencies = []\n# ///\n\n"
+        "# %% [markdown]\n# # Filtering\n\n"
+        '# %% tags=["jc.figure", "name=main"]\n'
+        "pass\n\n"
+        '# %% tags=["jc.figure", "name=debug"]\n'
+        "pass\n"
+    )
+
+    def _write_png(self, target: Path) -> None:
+        # Same 1x1 transparent PNG fixture used elsewhere.
+        payload = bytes.fromhex(
+            "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+            "89000000094944415478da63000100000500010d0a2db40000000049454e44ae"
+            "426082"
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+
+    def _bootstrap_two_figs(
+        self, tmp_path: Path
+    ) -> tuple[Path, Path, ArtifactRecord, ArtifactRecord]:
+        project = _bootstrap_project(tmp_path)
+        nb = _write_notebook(project, self._NOTEBOOK_TWO_FIGS)
+        main = project / "artifacts" / "main.png"
+        debug = project / "artifacts" / "debug.png"
+        self._write_png(main)
+        self._write_png(debug)
+        main_art = ArtifactRecord(
+            path="artifacts/main.png", sha256="a" * 64, size=main.stat().st_size
+        )
+        debug_art = ArtifactRecord(
+            path="artifacts/debug.png", sha256="b" * 64, size=debug.stat().st_size
+        )
+        return project, nb, main_art, debug_art
+
+    def test_no_tags_anywhere_means_include_all(self, tmp_path: Path) -> None:
+        """Regression: legacy notebooks still include every renderable artifact."""
+        project, nb, main_art, debug_art = self._bootstrap_two_figs(tmp_path)
+        manifests = {
+            "nb:1": _make_manifest("nb:1", artifacts=[main_art]),
+            "nb:2": _make_manifest("nb:2", artifacts=[debug_art]),
+        }
+        out = export_tearsheet(
+            nb,
+            manifests_by_cell=manifests,
+            output_path=project / "manuscripts" / "tearsheets" / "nb.md",
+            project_root=project,
+        )
+        text = out.read_text(encoding="utf-8")
+        assert "main.png" in text
+        assert "debug.png" in text
+
+    def test_artifact_level_tag_filters(self, tmp_path: Path) -> None:
+        """``jc.figure(tags=['tearsheet'])`` on one artifact excludes the untagged one."""
+        project, nb, main_art, debug_art = self._bootstrap_two_figs(tmp_path)
+        main_art.tags = ["tearsheet"]
+        manifests = {
+            "nb:1": _make_manifest("nb:1", artifacts=[main_art]),
+            "nb:2": _make_manifest("nb:2", artifacts=[debug_art]),
+        }
+        out = export_tearsheet(
+            nb,
+            manifests_by_cell=manifests,
+            output_path=project / "manuscripts" / "tearsheets" / "nb.md",
+            project_root=project,
+        )
+        text = out.read_text(encoding="utf-8")
+        assert "main.png" in text
+        # Debug figure excluded — untagged artifact under opt-in mode.
+        assert "debug.png" not in text
+
+    def test_cell_level_tag_filters(self, tmp_path: Path) -> None:
+        """Cell-level ``tearsheet`` tag marks every artifact from that cell."""
+        project = _bootstrap_project(tmp_path)
+        nb = _write_notebook(
+            project,
+            "# /// script\n# dependencies = []\n# ///\n\n"
+            "# %% [markdown]\n# # Filtering\n\n"
+            '# %% tags=["jc.figure", "name=main", "tearsheet"]\n'
+            "pass\n\n"
+            '# %% tags=["jc.figure", "name=debug"]\n'
+            "pass\n",
+        )
+        main = project / "artifacts" / "main.png"
+        debug = project / "artifacts" / "debug.png"
+        self._write_png(main)
+        self._write_png(debug)
+        main_art = ArtifactRecord(
+            path="artifacts/main.png", sha256="a" * 64, size=main.stat().st_size
+        )
+        debug_art = ArtifactRecord(
+            path="artifacts/debug.png", sha256="b" * 64, size=debug.stat().st_size
+        )
+        manifests = {
+            "nb:1": _make_manifest("nb:1", artifacts=[main_art]),
+            "nb:2": _make_manifest("nb:2", artifacts=[debug_art]),
+        }
+        out = export_tearsheet(
+            nb,
+            manifests_by_cell=manifests,
+            output_path=project / "manuscripts" / "tearsheets" / "nb.md",
+            project_root=project,
+        )
+        text = out.read_text(encoding="utf-8")
+        assert "main.png" in text
+        # Filter engaged because cell 1 has the tag; debug cell (no tag) excluded.
+        assert "debug.png" not in text
+
+    def test_json_artifacts_respect_filter(self, tmp_path: Path) -> None:
+        """Filtering works identically for JSON summaries, not just images."""
+        project = _bootstrap_project(tmp_path)
+        nb = _write_notebook(
+            project,
+            "# /// script\n# dependencies = []\n# ///\n\n"
+            '# %% tags=["jc.step", "name=report"]\n'
+            "pass\n\n"
+            '# %% tags=["jc.step", "name=diagnostic"]\n'
+            "pass\n",
+        )
+        (project / "artifacts").mkdir(exist_ok=True)
+        (project / "artifacts" / "headline.json").write_text(
+            json.dumps({"value": 42}), encoding="utf-8"
+        )
+        (project / "artifacts" / "scratch.json").write_text(
+            json.dumps({"debug": True}), encoding="utf-8"
+        )
+        headline = ArtifactRecord(
+            path="artifacts/headline.json",
+            sha256="a" * 64,
+            size=10,
+            tags=["tearsheet"],
+        )
+        scratch = ArtifactRecord(
+            path="artifacts/scratch.json", sha256="b" * 64, size=10
+        )
+        manifests = {
+            "nb:0": _make_manifest("nb:0", artifacts=[headline]),
+            "nb:1": _make_manifest("nb:1", artifacts=[scratch]),
+        }
+        out = export_tearsheet(
+            nb,
+            manifests_by_cell=manifests,
+            output_path=project / "manuscripts" / "tearsheets" / "nb.md",
+            project_root=project,
+        )
+        text = out.read_text(encoding="utf-8")
+        # Headline JSON is flattened into a table.
+        assert "`value`" in text
+        # Debug JSON not rendered at all.
+        assert "`debug`" not in text
         assert "Regenerating overwrites this file" in text

--- a/tests/unit/test_tearsheet.py
+++ b/tests/unit/test_tearsheet.py
@@ -531,9 +531,7 @@ class TestTearsheetTagFiltering:
             size=10,
             tags=["tearsheet"],
         )
-        scratch = ArtifactRecord(
-            path="artifacts/scratch.json", sha256="b" * 64, size=10
-        )
+        scratch = ArtifactRecord(path="artifacts/scratch.json", sha256="b" * 64, size=10)
         manifests = {
             "nb:0": _make_manifest("nb:0", artifacts=[headline]),
             "nb:1": _make_manifest("nb:1", artifacts=[scratch]),


### PR DESCRIPTION
## Summary

Closes #15.

Adds a declarative ``tearsheet`` tag that scopes which artifacts
inline into ``jellycell export tearsheet``. Notebooks with many
intermediate debug figures/JSONs can now produce a polished tearsheet
without deleting artifacts or hand-editing generated markdown.

```python
# Cell-level — all artifacts from this cell are included.
# %% tags=["jc.figure", "name=fig1", "tearsheet"]
jc.figure("artifacts/headline.png", caption="Main result")

# %% tags=["jc.figure", "name=debug"]
jc.figure("artifacts/debug.png")  # excluded once any cell has the tag

# Artifact-level — fine-grained for multi-artifact cells.
jc.save(debug_dict, "artifacts/debug.json")                # excluded
jc.save(headline, "artifacts/headline.json",
        tags=["tearsheet"])                                # included
```

Filtering is **auto-enabled** when any artifact or cell in the
notebook carries the tag. Untagged notebooks behave exactly as
before — strictly additive upgrade.

## Which option from the issue

Went with **option 1** (per-artifact/per-cell opt-in via tag).
Option 2 (``--include-artifacts`` glob flag) was also on the table;
chose tag-based because:

- **Declarative + persistent** — the notebook self-documents which
  artifacts are tearsheet-worthy. Every subsequent
  ``jellycell export tearsheet`` produces the same output without
  re-typing globs.
- **Quarto-aligned** — per-cell output-control tags (``#| output: false``)
  are the established community pattern.
- **Leaves room for option 2** — a future minor can layer
  ``--include-artifacts`` on top if one-off export scoping turns out
  to be needed on top of the tag.

If you'd prefer to ship option 2 alongside this PR, I can add it —
let me know.

## Behavior matrix

| Notebook state                     | Tearsheet output                 |
| ---------------------------------- | -------------------------------- |
| No tags anywhere                   | **Unchanged** — all artifacts    |
| Artifact-level tag on some         | Only tagged artifacts            |
| Cell-level tag on some             | Only artifacts from tagged cells |
| Both tag styles mixed              | Union of both (OR semantics)     |

## Backwards compatibility

Byte-for-byte identical for any notebook without ``tearsheet`` tags.
No existing test required modification; the 16 existing tearsheet
tests still pass with the new code paths threaded through.

## Versioning

Patch (assumes PRs #17 → #18 → #19 land first → this becomes
**1.3.5**). Happy to rebase if merge order changes.

## Contracts (§10)

- All unchanged. No cache-key, JSON schema, or agent-guide content
  touched. The tag is opt-in and additive.

## Test plan

- [x] `uv run pytest` — 384 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] `uv run python -m sphinx -W -b html docs docs/_build/html` — clean

New tests in `tests/unit/test_tearsheet.py::TestTearsheetTagFiltering`:

- `test_no_tags_anywhere_means_include_all` — regression: untagged
  notebooks stay in legacy all-inclusive mode.
- `test_artifact_level_tag_filters` — artifact-level
  ``tags=["tearsheet"]`` excludes untagged peers.
- `test_cell_level_tag_filters` — cell-level ``tearsheet`` in
  ``# %% tags=[...]`` marks every artifact from that cell.
- `test_json_artifacts_respect_filter` — filter applies equally to
  JSON summaries (not just images).

## Coordination

PR 4 of 4 (#17 jc.figure → #18 CLI --project → #19 jc.table → this).
Version sequential; only `CHANGELOG.md` + `_version.py` conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)