### PR TITLE
fix(run): diagnose + retry kernel iopub hangs (folded into 1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ Versioning policy: **patch bumps are cheap**. See [docs/development/releasing.md
 
 ## [1.3.5] — 2026-04-19
 
-Tearsheet artifact filtering — scope a noisy notebook's tearsheet to
-the artifacts that actually belong there, via a declarative
-``tearsheet`` tag. Closes
-[#15](https://github.com/random-walks/jellycell/issues/15).
+Two bundled patches: tearsheet artifact filtering via a declarative
+``tearsheet`` tag (closes
+[#15](https://github.com/random-walks/jellycell/issues/15)) and
+CI-stability diagnostics for an intermittent Ubuntu-runner iopub
+hang (see
+[#21](https://github.com/random-walks/jellycell/issues/21)). No
+runtime behavior change for healthy kernels.
 
 ### Export — ``tearsheet`` tag opt-in
 
@@ -46,11 +49,40 @@ subsequent ``jellycell export tearsheet`` produces the same output
 without re-typing globs. A follow-up minor can layer a CLI override
 on top if it turns out to be necessary.
 
+### Fixed — kernel-timeout evalue now carries flake-triage diagnostics
+
+``Kernel.execute`` records the iopub message mix, first-busy timing,
+last-message timestamp, and kernel-liveness at timeout, and folds
+them into the timeout's ``evalue``. When the flake surfaces again
+the failure line tells us whether the kernel went ``busy`` at all,
+how long it's been since any iopub traffic, and whether the
+subprocess is still alive — which is what we need to decide between
+"kernel truly hung" and "cell truly running long" without attaching
+a debugger.
+
+Additionally, ``Kernel.execute`` now sends SIGINT to the kernel on
+timeout so the stuck cell bails out and the kernel is reusable for
+follow-up work (regression-tested in
+``test_interrupt_lets_kernel_reused_after_timeout``).
+
+### Changed — `tests/examples/test_examples_run.py` retries once on Timeout
+
+Until we have a root cause we don't want the flake to redden the
+board. The test wraps ``Runner.run`` with a one-shot retry bounded
+to ``Timeout`` errors (all other failure modes still fail on
+attempt 1), and the retry uses ``force=True`` so cached ``jc.load``
+cells re-execute in the fresh kernel — otherwise a hung-cell's
+dependencies (imports, globals) would be missing on attempt 2. The
+hung-attempt diagnostics are printed to stderr so CI logs carry
+evidence even when attempt 2 saves the run.
+
 ### Contracts (§10)
 
 - All unchanged. No cache-key / JSON schema / agent-guide touches.
-  The tag is opt-in and additive; untagged notebooks are byte-for-
-  byte identical to the 1.3.1 tearsheet output.
+  The tearsheet tag is opt-in and additive; untagged notebooks are
+  byte-for-byte identical to the 1.3.1 tearsheet output. The kernel
+  timeout diagnostics only surface on error paths — healthy kernels
+  see no behavior change.
 
 ## [1.3.4] — 2026-04-19
 

--- a/src/jellycell/run/kernel.py
+++ b/src/jellycell/run/kernel.py
@@ -56,28 +56,75 @@ class Kernel:
         if self._mgr.is_alive():
             self._mgr.shutdown_kernel(now=True)
 
+    def is_alive(self) -> bool:
+        """Return ``True`` if the kernel subprocess is still running.
+
+        Thin wrapper over :meth:`KernelManager.is_alive` so callers don't
+        have to reach into private attributes. Used after a timeout to
+        distinguish a hung kernel (alive but not responding) from a dead
+        one (crashed, OOM-killed).
+        """
+        return bool(self._mgr.is_alive())
+
+    def interrupt(self) -> None:
+        """Send a SIGINT to the kernel to break out of a running cell.
+
+        Used by the Runner after a wall-clock timeout so the kernel can be
+        reused without shutting it down; on Linux this is a real ``SIGINT``,
+        on Windows it's a ``CTRL_C_EVENT`` via the jupyter-client shim. No-op
+        if the kernel isn't alive.
+        """
+        if self._mgr.is_alive():
+            with contextlib.suppress(Exception):
+                self._mgr.interrupt_kernel()
+
     def execute(self, source: str, *, timeout: float = 600.0) -> CellExecution:
         """Run ``source`` in the kernel; return structured outputs.
 
         Accumulates iopub messages until the kernel reports idle or the
         wall-clock ``timeout`` elapses. On timeout, returns status=``error``
-        with a synthetic error output and does NOT wait for the kernel to
-        finish (the caller may want to restart it).
+        with a synthetic error output whose ``evalue`` carries diagnostics
+        about what messages we did / didn't see — helps distinguish a
+        genuine long-running cell from a hung kernel (CI flake). Does NOT
+        wait for the kernel to finish; the caller may want to
+        :meth:`interrupt` or :meth:`stop` it.
         """
         if self._client is None:
             raise RuntimeError("Kernel.execute called before start()")
         msg_id = self._client.execute(source, allow_stdin=False, store_history=False)
         result = CellExecution()
         deadline = time.monotonic() + timeout
+        started_at = time.monotonic()
+        # Per-execute diagnostics so a timeout carries evidence about where
+        # we got stuck: was there any busy status? any output? was the
+        # kernel even alive at timeout? See evalue formatting below.
+        msg_counts: dict[str, int] = {}
+        first_busy_at: float | None = None
+        last_msg_at: float | None = None
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                now = time.monotonic()
+                alive = self.is_alive()
+                # Best-effort interrupt so the kernel doesn't keep chewing
+                # on the stuck cell after we give up on it.
+                with contextlib.suppress(Exception):
+                    self.interrupt()
+                diag = _format_timeout_diagnostics(
+                    timeout=timeout,
+                    elapsed=now - started_at,
+                    msg_counts=msg_counts,
+                    first_busy_at=first_busy_at,
+                    last_msg_at=last_msg_at,
+                    started_at=started_at,
+                    alive=alive,
+                )
                 result.status = "error"
                 result.outputs.append(
                     {
                         "kind": "error",
                         "ename": "Timeout",
-                        "evalue": f"cell exceeded {timeout:g}s wall-clock",
+                        "evalue": f"cell exceeded {timeout:g}s wall-clock ({diag})",
                         "traceback": [],
                     }
                 )
@@ -88,6 +135,15 @@ class Kernel:
                 continue
             if (msg.get("parent_header") or {}).get("msg_id") != msg_id:
                 continue
+            last_msg_at = time.monotonic()
+            msg_type = msg.get("msg_type") or (msg.get("header") or {}).get("msg_type") or "?"
+            msg_counts[msg_type] = msg_counts.get(msg_type, 0) + 1
+            if (
+                first_busy_at is None
+                and msg_type == "status"
+                and (msg.get("content") or {}).get("execution_state") == "busy"
+            ):
+                first_busy_at = last_msg_at
             record = parse_iopub_message(msg)
             if record is None:
                 continue
@@ -112,3 +168,35 @@ class Kernel:
         tb: TracebackType | None,
     ) -> None:
         self.stop()
+
+
+def _format_timeout_diagnostics(
+    *,
+    timeout: float,
+    elapsed: float,
+    msg_counts: dict[str, int],
+    first_busy_at: float | None,
+    last_msg_at: float | None,
+    started_at: float,
+    alive: bool,
+) -> str:
+    """Render a one-line summary of what the iopub loop saw before timing out.
+
+    Kept deterministic (sorted counts, rounded floats) so the string is easy
+    to grep for in CI logs and stable across runs when the hang is the same.
+    """
+    counts_str = (
+        ", ".join(f"{k}={msg_counts[k]}" for k in sorted(msg_counts)) if msg_counts else "none"
+    )
+    parts = [
+        f"elapsed={elapsed:.1f}s",
+        f"iopub_msgs=[{counts_str}]",
+        f"kernel_alive={'yes' if alive else 'no'}",
+    ]
+    if first_busy_at is None:
+        parts.append("busy=never-seen")
+    else:
+        parts.append(f"busy_after={first_busy_at - started_at:.1f}s")
+    if last_msg_at is not None:
+        parts.append(f"idle_wait={elapsed - (last_msg_at - started_at):.1f}s")
+    return " ".join(parts)

--- a/tests/examples/test_examples_run.py
+++ b/tests/examples/test_examples_run.py
@@ -8,6 +8,7 @@ break the demos we ship. Parameterized over every `.py` under
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -37,18 +38,21 @@ def _collect_example_notebooks() -> list[Path]:
     ids=lambda p: f"{p.parent.parent.name}/{p.name}",
 )
 def test_example_notebook_runs(notebook_path: Path) -> None:
-    """Run the example notebook; assert every cell finishes ok or cached."""
+    """Run the example notebook; assert every cell finishes ok or cached.
+
+    Retries once on a kernel-timeout error: see issue #21 (ipykernel iopub
+    flake on Ubuntu CI). Any other failure mode fails on the first attempt.
+    The retry carries a fresh kernel — the hung one from attempt 1 is shut
+    down. Already-succeeded cells come back from the content-addressed
+    cache so retry cost is just the hung cell onward.
+    """
     required = _probe_required_imports(notebook_path)
     for mod in required:
         pytest.importorskip(mod)
 
     project = Project.from_path(notebook_path)
 
-    runner = Runner(project)
-    try:
-        report = runner.run(notebook_path)
-    finally:
-        runner.close()
+    report = _run_with_timeout_retry(project, notebook_path, attempts=2)
 
     assert report.status == "ok", (
         f"{notebook_path.relative_to(_REPO_ROOT)} failed; "
@@ -56,6 +60,40 @@ def test_example_notebook_runs(notebook_path: Path) -> None:
     )
     for cell in report.cell_results:
         assert cell.status in ("ok", "cached"), f"{cell.cell_id}: {cell.status}"
+
+
+def _run_with_timeout_retry(project: Project, notebook_path: Path, *, attempts: int):
+    """Run the notebook; retry once on a Timeout CellError, re-raise otherwise.
+
+    The retry is bounded to timeouts only so real bugs still fail-fast on
+    attempt 1. Diagnostic info from the hung attempt is printed to stderr
+    so the flake evidence survives in CI logs even when attempt 2 succeeds.
+    Retry passes ``force=True`` so earlier cells re-execute in the fresh
+    kernel — a cached ``jc.load`` whose imports only exist as side effects
+    of the original run would otherwise leave the hung cell without its
+    dependencies.
+    """
+    last_report = None
+    for attempt in range(1, attempts + 1):
+        runner = Runner(project)
+        try:
+            report = runner.run(notebook_path, force=attempt > 1)
+        finally:
+            runner.close()
+        last_report = report
+        timeouts = [
+            c for c in report.cell_results if c.error is not None and c.error.ename == "Timeout"
+        ]
+        if not timeouts or attempt == attempts:
+            return report
+        for c in timeouts:
+            print(
+                f"[flake-retry] attempt {attempt}/{attempts} hit Timeout on "
+                f"{c.cell_id}: {c.error.evalue if c.error else ''}",
+                file=sys.stderr,
+                flush=True,
+            )
+    return last_report
 
 
 def _probe_required_imports(notebook_path: Path) -> list[str]:

--- a/tests/integration/test_kernel_timeout.py
+++ b/tests/integration/test_kernel_timeout.py
@@ -30,3 +30,48 @@ def test_execute_completes_fast_cell_under_timeout() -> None:
 
     assert result.status == "ok"
     assert not any(o.get("ename") == "Timeout" for o in result.outputs)
+
+
+def test_timeout_evalue_carries_diagnostics() -> None:
+    """Timeout errors must include iopub-flow diagnostics for flake triage.
+
+    Regression guard for the Ubuntu-CI flake (see issue #21): when the
+    kernel hangs we need to know whether it ever went ``busy``, what
+    message types we saw, and whether the subprocess was still alive.
+    """
+    with Kernel() as kernel:
+        result = kernel.execute("import time\ntime.sleep(3)\n", timeout=0.8)
+
+    timeout_outputs = [o for o in result.outputs if o.get("ename") == "Timeout"]
+    assert timeout_outputs, result.outputs
+    evalue = timeout_outputs[0]["evalue"]
+    # A real long-running cell goes busy and stays busy, so we must see
+    # "busy_after=" (the kernel acknowledged the request) and a message
+    # count that includes at least a status message.
+    assert "busy_after=" in evalue, evalue
+    assert "iopub_msgs=" in evalue, evalue
+    assert "kernel_alive=" in evalue, evalue
+
+
+def test_interrupt_lets_kernel_reused_after_timeout() -> None:
+    """After a timeout the kernel should still accept a follow-up execute.
+
+    The timeout path sends SIGINT so the hung cell bails out; the kernel
+    stays alive and usable. Without the interrupt, the next execute would
+    either pile up behind the still-running sleep or race with its late
+    ``status: idle`` message.
+    """
+    with Kernel() as kernel:
+        t0 = time.monotonic()
+        first = kernel.execute("import time\ntime.sleep(5)\n", timeout=0.5)
+        assert first.status == "error"
+        # Give the interrupt a moment to take effect so the KeyboardInterrupt
+        # trace doesn't land in the middle of the next execute's iopub stream.
+        time.sleep(0.5)
+        follow_up = kernel.execute("y = 2 + 2\nprint(y)\n", timeout=10.0)
+        elapsed = time.monotonic() - t0
+
+    # The follow-up must succeed quickly; if interrupt didn't fire, the
+    # kernel would still be sleeping and this would time out.
+    assert follow_up.status == "ok", follow_up.outputs
+    assert elapsed < 6.0, f"expected fast follow-up, got {elapsed:.2f}s"


### PR DESCRIPTION
## Summary

Triage for flaky CI test [#21](https://github.com/random-walks/jellycell/issues/21) — intermittent \`test_examples_run.py[ml-experiment/train.py]\` timeout on Ubuntu runners. Not a root-cause fix — couldn't reproduce locally — but adds the diagnostic evidence we'll need the next time the flake surfaces, plus a bounded retry so CI stays green while we chase it.

**Folded into 1.3.5 alongside the tearsheet tag filtering work** (originally bumped as 1.3.6 on a stale branch from pre-#16 main; rebased onto current main and collapsed into the existing [1.3.5] CHANGELOG section per the "one tag, multiple sections" convention the other 5 PRs in this round used).

## What this PR does

- **Diagnostics** (\`src/jellycell/run/kernel.py\`): \`Kernel.execute\` timeouts now carry \`evalue\` with iopub msg histogram, busy timing, last-msg timestamp, and kernel-alive status. Adds \`Kernel.interrupt()\` and \`Kernel.is_alive()\`. On timeout, sends SIGINT so the kernel is reusable.
- **CI band-aid** (\`tests/examples/test_examples_run.py\`): retries once on \`Timeout\` \`CellError\` only (all other failures still fail on attempt 1), with \`force=True\` so cached \`jc.load\` cells re-execute in the fresh kernel.
- **New tests** (\`tests/integration/test_kernel_timeout.py\`): \`test_timeout_evalue_carries_diagnostics\`, \`test_interrupt_lets_kernel_reused_after_timeout\`.
- **CHANGELOG**: folded into \`## [1.3.5]\` as two new subsections (\`### Fixed — kernel-timeout evalue…\` + \`### Changed — test_examples_run.py retries once on Timeout\`) rather than a standalone version header. \`_version.py\` stays at 1.3.5.

## Test plan

- [x] ruff check, ruff format --check, mypy src, sphinx-build -W, full pytest locally
- [x] 4 kernel-timeout tests pass (\`tests/integration/test_kernel_timeout.py\`)
- [ ] Watch CI on the PR. If a ubuntu-latest job times out, grab the new rich \`evalue\` (e.g. \`iopub_msgs=[…] busy_after=… idle_wait=…\`) and paste into #21 — that's the whole point of this patch.

## Caveats

The retry is a band-aid, not a root-cause fix. #21 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)