### PR TITLE
docs(audit): tearsheet tag + jc.figure path-only coverage (folded into 1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,11 +78,47 @@ evidence even when attempt 2 saves the run.
 
 ### Contracts (§10)
 
-- All unchanged. No cache-key / JSON schema / agent-guide touches.
-  The tearsheet tag is opt-in and additive; untagged notebooks are
-  byte-for-byte identical to the 1.3.1 tearsheet output. The kernel
-  timeout diagnostics only surface on error paths — healthy kernels
-  see no behavior change.
+- No cache-key / JSON schema touches. The tearsheet tag is opt-in and
+  additive; untagged notebooks are byte-for-byte identical to the
+  1.3.1 tearsheet output. The kernel timeout diagnostics only surface
+  on error paths — healthy kernels see no behavior change.
+- **§10.3 agent guide: additive content** — `tearsheet` tag added to
+  the attribute-tag vocabulary; `jc.figure` example updated to lead
+  with path-only invocation (1.3.2 feature, previously undocumented
+  in the guide). Snapshot `tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml`
+  regenerated (12140 → 12844 bytes; canonical headers preserved).
+
+### Docs + examples — post-PR audit cleanup
+
+Catch-up pass after the six 1.3.5 PRs landed so the user-facing surfaces
+document the new behavior end-to-end:
+
+- **`docs/agent-guide.md`** — `tearsheet` tag added to the attribute-tag
+  vocabulary table; `jc.figure` example rewritten to show the path-only
+  mode (PR #17) alongside the render mode.
+- **`docs/file-format.md`** — `tearsheet` row in the tag vocabulary;
+  short note on `jc.figure` path-only invocation.
+- **`docs/cli-reference.md`** — new "Filtering via the `tearsheet` tag"
+  subsection under `export tearsheet`; one-line note on `--project`
+  symmetry for `jellycell run` (PR #18).
+- **`context7.md`** — mirrors the doc updates so Context7 readers get
+  current guidance on `tearsheet` tag + `jc.figure` path-only mode.
+- **`CLAUDE.md`** — "Agent surface" section now enumerates current
+  `jellycell prompt` flag set (`--write`, `--nested`, `--force`,
+  `--agents-only`).
+- **`examples/demo`** — headline `summary.json` now carries
+  `tags=["tearsheet"]`; `headline.json` left untagged. Regenerated
+  `manuscripts/tearsheets/tour.md` demonstrates the filter
+  end-to-end (only the tagged artifact inlines).
+- **`examples/ml-experiment`** — `metrics.json` + `loss_curve.png`
+  gain `tearsheet` alongside their domain tags; `checkpoint.json` is
+  left untagged so the human-readable tearsheet shows the training
+  summary without the full loss history.
+- **`examples/monorepo/README.md`** — "Running a showcase" section
+  gains a third form (`--project`) with a concrete example using
+  every command (`run`, `render`, `view`, `lint`, `export tearsheet`),
+  and the pre-1.3.3 caveat about `--project X run notebooks/...` is
+  removed since PR #18 fixed the resolution.
 
 ## [1.3.4] — 2026-04-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ make release-check    # dry-run build + version print
 
 `jellycell prompt` emits the canonical agent guide — a single markdown doc covering layout, format, tags, API, and CLI reference. Content is the **§10.3 stability contract** (see [`docs/reference/contracts.md`](docs/reference/contracts.md)). Start by calling this in any new jellycell project.
 
+Flags: `--write [DIR]` drops `AGENTS.md` + `CLAUDE.md` at DIR (defaults to cwd); `--nested` acknowledges an outer `AGENTS.md` and writes an intentional inner override without needing `--force`; `--force` bypasses all safety checks; `--agents-only` skips the `CLAUDE.md` stub.
+
 ## Server vs. static
 
 `jellycell view` (live server) is **disk-write-free for HTML pages** — it renders in memory and caches responses by a notebook view-key. `jellycell render` (CLI) is the only path that populates `site/`. Live-mode assets land under `.jellycell/cache/assets/`; static-mode under `site/_assets/`. Both share the same Jinja templates. See [`docs/reference/architecture.md`](docs/reference/architecture.md#two-render-paths).

--- a/context7.md
+++ b/context7.md
@@ -83,6 +83,7 @@ jc.table(summary, caption="Sales summary")
 - **PEP-723 script header**: `requires-python` + `dependencies` + optional `[tool.jellycell]` file-scope overrides (allow-listed keys: `project.name`, `run.kernel`, `run.timeout_seconds`).
 - **Cell tags**: `# %% tags=[...]` markers carry `cell-id`, `name`, `kind`, `deps`, `timeout_s`. Parsed by `jellycell.format`.
 - **Cell kinds** (declared via `kind=`): `load`, `setup`, `step`, `figure`, `table`. Drives lint and tearsheet rendering.
+- **`tearsheet` tag** (1.3.5+): orthogonal to kind. Drop it on a cell (`tags=["jc.figure", "tearsheet"]`) or an artifact (`jc.save(x, path, tags=["tearsheet"])`) to filter which artifacts inline into `jellycell export tearsheet`. Any `tearsheet` tag in a notebook auto-enables filtering; no tags = every artifact inlined (old behavior).
 
 ## The `jc.*` API
 
@@ -92,7 +93,7 @@ jc.table(summary, caption="Sales summary")
 | --- | --- |
 | `jc.load(path)` | Read input; registers an implicit dep edge on the producing cell via the artifact lineage index |
 | `jc.save(obj, path, caption=..., notes=..., tags=[...])` | Write an artifact; metadata lands on the `ArtifactRecord` in the cell manifest |
-| `jc.figure(fig=..., caption=..., notes=..., tags=[...])` | Save a matplotlib figure (auto-path via `[artifacts] layout`) |
+| `jc.figure(path, fig=..., caption=..., notes=..., tags=[...])` | Save a matplotlib figure, or with no `fig=` and an existing file at `path`, register it without re-encoding (1.3.2+) |
 | `jc.table(df, caption=..., notes=..., tags=[...])` | Save a dataframe as markdown or parquet (layout-driven) |
 | `jc.deps("a", "b")` | Runtime-declared deps; AST-walked into the current cell's cache key |
 | `jc.cache` | Decorator that memoizes function calls via the content-addressed store |

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -91,12 +91,20 @@ Tags live in the `tags=[...]` list on the cell marker:
 | `jc.table`   | Writes a tabular artifact                     | `name=`              |
 | `jc.setup`   | No deps; not cached; runs first               | —                    |
 | `jc.note`    | Markdown-only; not executable                 | —                    |
+| `tearsheet`  | Include this cell/artifact in `jellycell export tearsheet` | — |
 
 `deps=a,b` declares that this cell depends on cells named `a` and `b`. The
 cache key incorporates dep cells' hashes so invalidation propagates correctly.
 
 Untagged code cells default to `jc.step` with an auto-generated name like
 `<notebook>:<ordinal>`.
+
+`tearsheet` is orthogonal — drop it on any cell (`tags=["jc.figure",
+"tearsheet"]`) or pass it to any artifact call (`jc.save(x, path,
+tags=["tearsheet"])`). As soon as *any* artifact in a notebook carries the
+tag, `jellycell export tearsheet` auto-enables filtering and includes only
+tagged artifacts. Notebooks with zero `tearsheet` tags are unaffected —
+every renderable artifact inlines as before.
 
 ## The `jc.*` API
 
@@ -108,6 +116,12 @@ import jellycell.api as jc
 # writes — all take optional caption=/notes=/tags= metadata
 jc.save(obj, "artifacts/summary.json", caption="Headline stats")
 jc.save(df, "artifacts/data.parquet")
+
+# jc.figure — two forms:
+# 1) Path-only: register an existing image file as an artifact (no re-encode).
+jc.figure("artifacts/plot.png", caption="Figure 1: mortality by country")
+
+# 2) Render: save a matplotlib figure.
 jc.figure(
     "artifacts/plot.png",
     fig=plt.gcf(),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -57,7 +57,13 @@ Execute a notebook end-to-end with caching.
 jellycell run notebooks/foo.py
 jellycell run notebooks/foo.py --force                    # re-execute all cells
 jellycell run notebooks/foo.py -m "fixed sign error"      # journal entry message
+jellycell --project other/ run notebooks/foo.py           # resolve under other/
 ```
+
+`--project ROOT` (global) resolves the notebook under `ROOT/` first and
+falls back to cwd (fixed in 1.3.3, [#12](https://github.com/random-walks/jellycell/issues/12)).
+Now works symmetrically with `render`, `lint`, `cache`, `checkpoint`,
+`new`, `view`, and `export *`.
 
 After the run, `jellycell run` warns about any artifact larger than
 `[artifacts] max_committed_size_mb` (default 50) with `.gitignore` / Git
@@ -116,6 +122,15 @@ when iterating on templates so every request re-renders.
   paths, JSON summaries flattened as two-column tables, and a header
   link to `site/<stem>.html` when it exists. Safe to commit; GitHub
   renders it inline.
+
+  **Filtering via the `tearsheet` tag** (1.3.5+): mark the artifacts
+  worth inlining with `tags=["tearsheet"]`, either on the cell
+  (`# %% tags=["jc.figure", "tearsheet"]`) or the artifact call
+  (`jc.save(x, "artifacts/key.json", tags=["tearsheet"])`). As soon as
+  any artifact in the notebook carries the tag, tearsheet filtering
+  auto-enables and untagged artifacts are excluded. Notebooks with no
+  `tearsheet` tagging behave as before — every renderable artifact is
+  inlined. Closes [#15](https://github.com/random-walks/jellycell/issues/15).
 
 ### `jellycell checkpoint ...`
 

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -90,8 +90,14 @@ The `tags=[...]` list on the marker line. Two classes of tags:
 | `name=...`         | Cell's name. Referenceable via `deps=` elsewhere. | `name=summary`  |
 | `deps=a,b,c`       | Explicit deps. Comma-separated list of names.     | `deps=raw,env`  |
 | `timeout=N`        | Per-cell timeout in seconds                       | `timeout=60`    |
+| `tearsheet`        | Include this cell/artifact in `export tearsheet`  | `tearsheet`     |
 
 Tags round-trip losslessly through jupytext — verified by tests.
+
+**`jc.figure` accepts path-only invocation** (1.3.2+): call
+`jc.figure("artifacts/foo.png")` with no `fig=` and an existing file on disk
+to register it as an artifact without re-encoding. See the
+[agent guide](agent-guide.md) for the full two-mode signature.
 
 ## Cache-key semantics
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -56,6 +56,10 @@ demo/
   hand-written `deps=` needed.
 - **JSON → tearsheet table** — every `jc.save(dict, "...json")` becomes
   a two-column markdown table in the tearsheet.
+- **`tearsheet` tag filtering** (1.3.5+) — only `summary.json` carries
+  `tags=["tearsheet"]` so the auto-tearsheet is scoped to the headline
+  result. `headline.json` is saved but not inlined. Remove the tag to
+  see every artifact in the tearsheet (old default behavior).
 - **Cache invalidation on source edit** — change `CONVERSIONS` in the
   setup cell and watch the next run re-execute only the affected subgraph.
 

--- a/examples/demo/manuscripts/tearsheets/tour.md
+++ b/examples/demo/manuscripts/tearsheets/tour.md
@@ -1,6 +1,6 @@
 # jellycell tour
 
-> **Tearsheet** for [`notebooks/tour.py`](../../notebooks/tour.py) · [HTML report](../../site/tour.html) · last run `2026-04-18T19:02:16+00:00`
+> **Tearsheet** for [`notebooks/tour.py`](../../notebooks/tour.py) · [HTML report](../../site/tour.html) · last run `2026-04-19T19:19:01+00:00`
 
 Exercises the core `jc.*` API without external deps. Run with
 `jellycell run notebooks/tour.py`, then `jellycell export tearsheet
@@ -30,7 +30,7 @@ constructing a literal.
 
 The tearsheet auto-renders the saved JSON as a key/value table.
 
-**Summary**
+**Conversion headline**
 
 | field | value |
 | --- | --- |
@@ -38,6 +38,8 @@ The tearsheet auto-renders the saved JSON as a key/value table.
 | `total_sessions` | `450` |
 | `conversion_rate` | `0.0844` |
 | `conversions` | `38` |
+
+_tags: tearsheet_
 
 
 ## 5. Round-trip via `jc.load`
@@ -50,13 +52,6 @@ automatically, no hand-written `deps=` needed.
 
 Change `CONVERSIONS` in the setup cell and only the downstream
 subgraph (`rate` → `summary` → this cell) re-runs.
-
-**Headline**
-
-| field | value |
-| --- | --- |
-| `headline` | 38 of 450 sessions converted |
-
 
 ---
 

--- a/examples/demo/notebooks/tour.py
+++ b/examples/demo/notebooks/tour.py
@@ -52,7 +52,12 @@ summary = {
     "conversion_rate": round(conversion_rate, 4),
     "conversions": raw["conversions"],
 }
-jc.save(summary, "artifacts/summary.json")
+jc.save(
+    summary,
+    "artifacts/summary.json",
+    caption="Conversion headline",
+    tags=["tearsheet"],
+)
 
 # %% [markdown]
 # ## 5. Round-trip via `jc.load`

--- a/examples/ml-experiment/README.md
+++ b/examples/ml-experiment/README.md
@@ -35,6 +35,12 @@ jellycell view
   flattens `metrics.json` into a two-column table.
 - **Figure inlined in the tearsheet** — `loss_curve.png` drops into
   the tearsheet via a relative path.
+- **`tearsheet` tag filtering** (1.3.5+) — `metrics.json` and
+  `loss_curve.png` carry `tags=["tearsheet"]` alongside their domain
+  tags (`training`, `result`, `diagnostic`); `checkpoint.json` does
+  not. The auto-tearsheet scopes to the training summary — the full
+  loss history lives in `checkpoint.json` for agents/tools that want
+  it, but doesn't clutter the human-readable tearsheet.
 - **Deterministic, CI-friendly** — `SEED = 0` + small dataset means CI
   gets the same loss curve every time. Swap `TRUE_W` or `NOISE` to vary
   the experiment.

--- a/examples/ml-experiment/manuscripts/tearsheets/train.md
+++ b/examples/ml-experiment/manuscripts/tearsheets/train.md
@@ -1,6 +1,6 @@
 # Tiny training loop
 
-> **Tearsheet** for [`notebooks/train.py`](../../notebooks/train.py) · [HTML report](../../site/train.html) · last run `2026-04-18T19:02:18+00:00`
+> **Tearsheet** for [`notebooks/train.py`](../../notebooks/train.py) · [HTML report](../../site/train.html) · last run `2026-04-19T19:19:44+00:00`
 
 A one-parameter linear regression fit with gradient descent, plus a
 loss curve and final metrics. Every run dumps:
@@ -23,7 +23,7 @@ NOISE = 0.25
 
 ![loss_curve](../../artifacts/loss_curve.png)
 *Monotone decrease, no oscillation, no divergence — LR and batch size are in a stable regime for this dataset. 40 epochs not quite enough for convergence (see model-card.md).*
-_tags: training, diagnostic_
+_tags: training, diagnostic, tearsheet_
 
 
 **Table 1: end-of-training metrics**
@@ -40,15 +40,7 @@ _tags: training, diagnostic_
 
 *final_weight vs target_weight shows how far the optimizer got. weight_error_abs = |target − fitted|.*
 
-_tags: training, result_
-
-
-**Checkpoint**
-
-| field | value |
-| --- | --- |
-| `weight` | `0.7903` |
-| `history` | `[40 items]` |
+_tags: training, result, tearsheet_
 
 
 ---

--- a/examples/ml-experiment/notebooks/train.py
+++ b/examples/ml-experiment/notebooks/train.py
@@ -63,7 +63,7 @@ jc.figure(
         "size are in a stable regime for this dataset. 40 epochs not quite "
         "enough for convergence (see model-card.md)."
     ),
-    tags=["training", "diagnostic"],
+    tags=["training", "diagnostic", "tearsheet"],
 )
 
 # %% tags=["jc.step", "name=metrics", "deps=train"]
@@ -84,7 +84,7 @@ jc.save(
         "final_weight vs target_weight shows how far the optimizer got. "
         "weight_error_abs = |target − fitted|."
     ),
-    tags=["training", "result"],
+    tags=["training", "result", "tearsheet"],
 )
 print(metrics)
 

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -68,7 +68,7 @@ uv run jellycell prompt --write --force
 
 ## Running a showcase
 
-Two equivalent forms. Pick whichever matches your muscle memory:
+Three equivalent forms. Pick whichever matches your muscle memory:
 
 ```bash
 # A) Full path from the monorepo root — jellycell discovers the
@@ -82,24 +82,23 @@ cd showcase-marketing
 uv run jellycell run notebooks/tour.py
 uv run jellycell render
 uv run jellycell view
-```
 
-For commands that don't take a notebook argument (`render` /
-`view` / `lint` / `export`), use `--project` with no notebook:
-
-```bash
+# C) --project global flag — works symmetrically across every command,
+#    including those that take a notebook argument (1.3.3+).
+uv run jellycell --project showcase-marketing run notebooks/tour.py
 uv run jellycell --project showcase-marketing render
 uv run jellycell --project showcase-marketing view            # live viewer on :5179
 uv run jellycell --project showcase-churn    lint --fix
+uv run jellycell --project showcase-churn    export tearsheet notebooks/tour.py
 ```
 
-Either form uses the same `.venv` at the monorepo root — no per-
-showcase environment setup.
+`--project ROOT` resolves a notebook path against `ROOT/` first, falling
+back to cwd if the project-relative path doesn't exist; absolute paths
+are honored verbatim. Works for `run`, `render`, `view`, `lint`, `new`,
+`cache`, `checkpoint`, and every `export *` — one flag, same semantics.
 
-> `jellycell --project X run notebooks/tour.py` does **not** rewrite
-> `notebooks/tour.py` to live under `X/` — that path is resolved
-> against your current working directory. Use form A (full path) or B
-> (`cd`) when running a notebook.
+Every form uses the same `.venv` at the monorepo root — no per-showcase
+environment setup.
 
 ## What gets committed vs git-ignored
 

--- a/tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml
+++ b/tests/unit/test_prompt_snapshot/test_prompt_snapshot.yml
@@ -3,6 +3,6 @@ contains_canonical_headers:
   cli_commands_section: true
   invariants_section: true
   jc_api_section: true
-length: 12140
-sha256_first_32: d572a98c36cccb98a43da498b12e3a05
+length: 12844
+sha256_first_32: 23c0cd5fb9130d3d51e76d8d8454b823
 starts_with: '# Agent guide'


### PR DESCRIPTION
## Summary

Post-PR audit pass after the six 1.3.5 PRs landed. Upstream-landscape research (AGENTS.md spec, Context7 schema, Cursor/Codex tooling, agentic ecosystem) turned up nothing material changed in the last five days — jellycell's infra choices still match best practice, so this is pure internal catch-up: get the user-facing surfaces to document the new behavior before we tag v1.3.5.

Two concrete coverage gaps surfaced by the audit:

1. **`tearsheet` tag** (PR #20) never appeared in the agent-guide vocabulary, the file-format tag table, the CLI reference's \`export tearsheet\` section, `context7.md`, or ANY example. Biggest user-facing feature of 1.3.5, effectively invisible.
2. **`jc.figure` path-only mode** (PR #17, landed in 1.3.2) was never added to the agent-guide or file-format — docs still led with the `fig=` form only.

## Changes

**Docs (§10.3 additive):**
- `docs/agent-guide.md` gets a `tearsheet` row + `jc.figure` example rewrite (snapshot regenerated 12140 → 12844 bytes; canonical headers preserved).
- `docs/file-format.md` + `docs/cli-reference.md` + `context7.md` + `CLAUDE.md` — parallel updates so every surface agrees.

**Examples:**
- `examples/demo` — `summary.json` gets `tags=[\"tearsheet\"]`; `headline.json` left untagged. Regenerated tearsheet is scoped to the one tagged artifact → live demo of the filter.
- `examples/ml-experiment` — `metrics.json` + `loss_curve.png` get `tearsheet`; `checkpoint.json` stays untagged so the full loss history doesn't clutter the tearsheet. Regenerated.
- `examples/monorepo/README.md` — new third form showing `--project` works symmetrically across `run` / `render` / `view` / `lint` / `export` / etc. Removes the stale pre-1.3.3 caveat.

**CHANGELOG:** new `### Docs + examples — post-PR audit cleanup` subsection folded into the existing `[1.3.5]` entry. No additional version bump.

## Test plan

- [x] \`make lint\`: clean
- [x] \`make test\`: 407 passed (prompt snapshot regenerated for the §10.3 additive)
- [x] \`make docs-build\`: strict; llms-full.txt captures new content
- [x] \`make release-check\`: builds \`jellycell-1.3.5\` wheel + sdist
- [x] Smoke from the monorepo example: \`jellycell --project showcase-marketing render\` works as documented
- [x] Regenerated demo + ml-experiment tearsheets reflect the tag filter end-to-end
- [ ] **Post-merge: tag \`v1.3.5\`** — this is the real cut. Six feature PRs (#16, #17, #18, #19, #20, #22) + this audit cleanup all land under one tag. Release workflow fires on the tag, PyPI publishes 1.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)